### PR TITLE
Support the use of the catalina.base for multi-instance tomcat installations

### DIFF
--- a/Server/src/main/java/org/xdi/oxauth/model/config/ConfigurationFactory.java
+++ b/Server/src/main/java/org/xdi/oxauth/model/config/ConfigurationFactory.java
@@ -40,9 +40,10 @@ public class ConfigurationFactory {
 
     private static final Log LOG = Logging.getLog(ConfigurationFactory.class);
 
-    private static final String BASE_DIR = System.getProperty("catalina.home") != null ?
-            System.getProperty("catalina.home") :
-            System.getProperty("jboss.home.dir");
+    private static final String BASE_DIR =
+            System.getProperty("catalina.base") != null ? System.getProperty("catalina.base") :
+            System.getProperty("catalina.home") != null ? System.getProperty("catalina.home") :
+            System.getProperty("jbosss.home.dir");
     private static final String DIR = BASE_DIR + File.separator + "conf" + File.separator;
 
     private static final String CONFIG_FILE_PATH = DIR + "oxauth-config.xml";


### PR DESCRIPTION
Multi-instance tomcat installations have a single CATALINA_HOME where the tomcat shared libraries are stored and can have one or more CATALINA_BASE directories which contains a local instance of tomcat with customized configs. The ubuntu packages, tomcat{6,7}-user, assist in creating such multi-instance installations by generating a new CATALINA_BASE directory with a copy of the essential configs. Ideally, a tomcat application will first look for its config files under CATALINA_BASE first, then CATALINA_HOME.

Right now oxauth only checks CATALINA_HOME for its configs. This patch should help oxauth to be deployed in cases where configs are stored in CATALINA_BASE instead of CATALINA_HOME.