### PR TITLE
Retrieve the session_state from the opbs cookie rather than calculating it

### DIFF
--- a/Server/src/main/webapp/opiframe.xhtml
+++ b/Server/src/main/webapp/opiframe.xhtml
@@ -5,7 +5,6 @@
     <title>
         oxAuth - OP iFrame
     </title>
-    <script type="text/javascript" src="//crypto-js.googlecode.com/svn/tags/3.0.2/build/rollups/sha256.js"></script>
     <script>
         //<![CDATA[
         window.addEventListener("message", receiveMessage, false);

--- a/Server/src/main/webapp/opiframe.xhtml
+++ b/Server/src/main/webapp/opiframe.xhtml
@@ -15,12 +15,9 @@
             var client_id = message.split(' ')[0];
             var session_state = message.split(' ')[1];
 
-            var salt = session_state.split('.')[1];
             var opbs = getCookie("opbs");
 
-            var ss = CryptoJS.SHA256(client_id + ' ' + e.origin + ' ' + opbs + ' ' + salt) + "." + salt;
-
-            if (session_state == ss) {
+            if (session_state == opbs) {
                 stat = "unchanged";
             } else {
                 stat = "changed";


### PR DESCRIPTION
This pull request is in reference to
https://support.gluu.org/integrations/opiframe-javascript-produces-unverifiable-session_state-2419#at8012

The opiframe.xhtml page implements the OP iframe in the OpenID Connect Session Management specification (https://openid.net/specs/openid-connect-session-1_0.html#OPiframe). It can receive html postMessage containing a "client_id session_state" and compare it to the oxAuth cookie that stores the session state.

The javascript receiveMessage function in the opiframe attempts to calculate the session_state as a salted SHA256 sum by following the non-normative example in the specification. However, oxAuth does not return session_state as a salted SHA256 sum, and instead generates a UUID server-side, which is also stored in the opbs cookie. Client-side calculation thus does not work.

This pull request compares the opbs cookie with the submitted session_state instead of calculating it client-side. It's been tested to generate the proper postMessage to the RP iframe on session changes.