### PR TITLE
Do not force the use of relative paths for css, images, or javascripts.

### DIFF
--- a/Server/conf/oxauth-config.json
+++ b/Server/conf/oxauth-config.json
@@ -212,9 +212,9 @@
     "sessionIdEnabled":true,
     "sessionIdPersistOnPromptNone":false,
     "configurationUpdateInterval":3600,
-    "cssLocation":"/${config.oxauth.contextPath}/stylesheet",
-    "jsLocation":"/${config.oxauth.contextPath}/js",
-    "imgLocation":"/${config.oxauth.contextPath}/img",
+    "cssLocation":"${config.oxauth.contextPath}/stylesheet",
+    "jsLocation":"${config.oxauth.contextPath}/js",
+    "imgLocation":"${config.oxauth.contextPath}/img",
     "metricReporterInterval":300,
     "metricReporterKeepDataDays":15
 }


### PR DESCRIPTION
The website asset paths (cssLocation, imgLocation, and jsLocation) stored in the oxauth-config.json template all use a compile time variable config.oxauth.contextPath prefixed with a "/", forcing the assets to be relative to the current url. HOWEVER, config.oxauth.contextPath is NOT set as a relative URL in the relevant sample properties files (it defaults to https://localhost:8443), nor is it used this way in the other entries that use it (authorizationEndpoint, tokenEndpoint, userInfoEndpoint, etc). This commit changes the default profile to remove the "/" prefix from the assets paths.