### PR TITLE
Use catalina.base instead of catalina.home for log files to support m…

### DIFF
--- a/RP/src/main/resources/log4j.xml
+++ b/RP/src/main/resources/log4j.xml
@@ -3,7 +3,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
 
     <appender name="FILE" class="org.apache.log4j.DailyRollingFileAppender">
-    <param name="File" value="${catalina.home}/logs/oxauth-rp.log"/>
+    <param name="File" value="${catalina.base}/logs/oxauth-rp.log"/>
     <param name="DatePattern" value="'.'yyyy-MM-dd"/>
         <layout class="org.apache.log4j.PatternLayout">
             <!-- The default pattern: Date Priority [Category] Message\n -->

--- a/Server/src/main/resources/log4j.xml
+++ b/Server/src/main/resources/log4j.xml
@@ -10,7 +10,7 @@
     </appender>
 
     <appender name="FILE" class="org.apache.log4j.DailyRollingFileAppender">
-        <param name="File" value="${catalina.home}/logs/oxauth.log"/>
+        <param name="File" value="${catalina.base}/logs/oxauth.log"/>
         <param name="DatePattern" value="'.'yyyy-MM-dd"/>
         <param name="BufferSize" value="1000"/>
         <layout class="org.apache.log4j.PatternLayout">
@@ -24,7 +24,7 @@
     <!-- ================ -->
 
     <appender name="OX_PERSISTENCE_LDAP_STATISTICS_FILE" class="org.apache.log4j.DailyRollingFileAppender">
-         <param name="File" value="${catalina.home}/logs/oxauth_persistence_ldap_statistics.log"/>
+         <param name="File" value="${catalina.base}/logs/oxauth_persistence_ldap_statistics.log"/>
          <param name="DatePattern" value="'.'yyyy-MM-dd"/>
 
          <layout class="org.apache.log4j.PatternLayout">
@@ -34,7 +34,7 @@
    </appender>
 
     <appender name="OX_SCRIPT_LOG_FILE" class="org.apache.log4j.DailyRollingFileAppender">
-         <param name="File" value="${catalina.home}/logs/oxauth_script.log"/>
+         <param name="File" value="${catalina.base}/logs/oxauth_script.log"/>
          <param name="DatePattern" value="'.'yyyy-MM-dd"/>
 
          <layout class="org.apache.log4j.PatternLayout">


### PR DESCRIPTION
…ulti-instance tomcat.

Tomcat allows multiple instances to be installed using the same binary. In debian, this is performed by the tomcat7-user package. In centos, this can be achieved by customizing the init script and copying a skeleton tomcat directory structure. In both cases, tomcat sets the CATALINA_HOME environment variable (catalina.home for java) to the location of the tomcat binary, and the CATALINA_BASE environment variable (catalina.base for java) to the location of the tomcat installation. catalina.sh describes that CATALINA_BASE will be set to CATALINA_HOME if not present.

    #   CATALINA_HOME   May point at your Catalina "build" directory.
    #
    #   CATALINA_BASE   (Optional) Base directory for resolving dynamic portions
    #                   of a Catalina installation.  If not present, resolves to
    #                   the same directory that CATALINA_HOME points to.

Since CATALINA_BASE contains the "dynamic portions" of the Catalina installation, this is the appropriate place to look for log files.

In the default oxauth installation, however, log4j is configured to create / look for the log files under CATALINA_HOME, which results in permissions / file not found errors if a tomcat instance is run.

This patch sets logfiles to be created / found under catalina.base rather than catalina.home. If CATALINA_BASE is not set, catalina will be setting it to CATALINA_HOME anyways, so there shouldn't be any damage done.