### PR TITLE
Fix null pointer on 3.0.0 (ticket #3743)

### DIFF
--- a/Server/integrations/basic.multi_auth_conf/BasicMultiAuthConfExternalAuthenticator.py
+++ b/Server/integrations/basic.multi_auth_conf/BasicMultiAuthConfExternalAuthenticator.py
@@ -4,6 +4,7 @@
 # Author: Yuriy Movchan
 #
 
+from org.jboss.seam import Component
 from org.jboss.seam.security import Identity
 from org.xdi.model.custom.script.type.auth import PersonAuthenticationType
 from org.xdi.oxauth.service import UserService, AuthenticationService, AppInitializer
@@ -200,7 +201,7 @@ class PersonAuthentication(PersonAuthenticationType):
     def createLdapExtendedEntryManagers(self, authConfiguration):
         ldapExtendedConfigurations = self.createLdapExtendedConfigurations(authConfiguration)
         
-        appInitializer = AppInitializer.instance()
+        appInitializer = Component.getInstance(AppInitializer)
 
         ldapExtendedEntryManagers = []
         for ldapExtendedConfiguration in ldapExtendedConfigurations:


### PR DESCRIPTION
AppInitializer.instance() doesn't seem to be defined anymore and is throwing a null pointer exception in Jython.

Replacing with Component.getInstance() instead.