### PR TITLE
Issue 590.

### DIFF
--- a/Server/src/main/java/org/xdi/oxauth/auth/AuthenticationFilter.java
+++ b/Server/src/main/java/org/xdi/oxauth/auth/AuthenticationFilter.java
@@ -299,6 +299,16 @@ public class AuthenticationFilter implements Filter {
 
 						requireAuth = !authenticator.authenticateWebService(true);
 					}
+				} else {
+					Client client = clientService.getClient(servletRequest.getParameter("client_id"));
+					if (client != null && client.getAuthenticationMethod() == AuthenticationMethod.NONE) {
+						identity.logout();
+
+						identity.getCredentials().setUsername(client.getClientId());
+						identity.getCredentials().setPassword(null);
+
+						requireAuth = !authenticator.authenticateWebService(true);
+					}
 				}
 			}
 


### PR DESCRIPTION
#590: removed the need to pass client_secret to '/oxauth/restv1/token' endpoint if client authorization method is 'none'.