### PR TITLE
Users enrolled through Google+ now have SCIM emails array set

### DIFF
--- a/Server/integrations/gplus/GooglePlusExternalAuthenticator.py
+++ b/Server/integrations/gplus/GooglePlusExternalAuthenticator.py
@@ -17,7 +17,6 @@ from org.xdi.oxauth.service import UserService, ClientService, AuthenticationSer
 from org.xdi.service.cdi.util import CdiUtil
 from org.xdi.util import StringHelper, ArrayHelper
 
-
 class PersonAuthentication(PersonAuthenticationType):
     def __init__(self, currentTimeMillis):
         self.currentTimeMillis = currentTimeMillis
@@ -225,6 +224,21 @@ class PersonAuthentication(PersonAuthenticationType):
  
                     if (newUser.getAttribute("cn") == None):
                         newUser.setAttribute("cn", gplusUserUid)
+
+                    # Add mail to oxTrustEmail so that the user's
+                    # email is available through the SCIM interface
+                    # too.
+                    if (newUser.getAttribute("oxTrustEmail") is None and
+                        newUser.getAttribute("mail") is not None):
+                        oxTrustEmail = {
+                            "value": newUser.getAttribute("mail"),
+                            "display": newUser.getAttribute("mail"),
+                            "primary": True,
+                            "operation": None,
+                            "reference": None,
+                            "type": "other"
+                        }
+                        newUser.setAttribute("oxTrustEmail", json.dumps(oxTrustEmail))
 
                     newUser.setAttribute("oxExternalUid", "gplus:" + gplusUserUid)
                     print "Google+ Authenticate for step 1. Attempting to add user '%s' with next attributes '%s'" % (gplusUserUid, newUser.getCustomAttributes())


### PR DESCRIPTION
- When enrolling users through Google+/Google OAuth2, the user created
  in Gluu's LDAP did not have the oxTrustEmail attribute
  set. Consequentially, the email array of these users, when queried
  through the SCIM REST API, was empty.

- This has now been remedied. The following email entry is added to
  the SCIM JSON structure for a user created through G+:
```
      "emails": [
        {
          "operation": null,
          "value": "user@gmail.com",
          "display": "user@gmail.com",
          "primary": true,
          "reference": null,
          "type": "other"
        }
      ],
```
- Roughly equivalent to
  org.gluu.oxtrust.util.ServiceUtil#syncEmailReverse (which can't be
  used becaues the models are different).