### PR TITLE
Don't throw NPE when there is no legacyDynamicRegistrationScopeParam in

### DIFF
--- a/Client/src/test/java/org/xdi/oxauth/ws/rs/MultiStepAuthorizationCodeFlowHttpTest.java
+++ b/Client/src/test/java/org/xdi/oxauth/ws/rs/MultiStepAuthorizationCodeFlowHttpTest.java
@@ -40,7 +40,7 @@ public class MultiStepAuthorizationCodeFlowHttpTest extends BaseTest {
     public void authorizationMultiStepCodeFlow(
             final String userId, final String userSecret, final String redirectUris, final String redirectUri,
             final String sectorIdentifierUri) throws Exception {
-        showTitle("authorizationCodeFlow");
+        showTitle("authorizationMultiStepCodeFlow");
 
         List<ResponseType> responseTypes = Arrays.asList(
                 ResponseType.CODE,

--- a/Model/src/main/java/org/xdi/oxauth/model/configuration/AppConfiguration.java
+++ b/Model/src/main/java/org/xdi/oxauth/model/configuration/AppConfiguration.java
@@ -1299,7 +1299,7 @@ public class AppConfiguration implements Configuration {
     }
 
     public Boolean getLegacyDynamicRegistrationScopeParam() {
-        return legacyDynamicRegistrationScopeParam;
+        return Boolean.TRUE.equals(legacyDynamicRegistrationScopeParam);
     }
 
     public void setLegacyDynamicRegistrationScopeParam(Boolean legacyDynamicRegistrationScopeParam) {


### PR DESCRIPTION
config