### PR TITLE
Version 3.1.3 enable admin to turn off authz for openid scope

### DIFF
--- a/Client/src/test/java/org/xdi/oxauth/ws/rs/AuthorizeRestWebServiceHttpTest.java
+++ b/Client/src/test/java/org/xdi/oxauth/ws/rs/AuthorizeRestWebServiceHttpTest.java
@@ -33,7 +33,7 @@ import static org.xdi.oxauth.model.register.RegisterRequestParam.*;
  * Functional tests for Authorize Web Services (HTTP)
  *
  * @author Javier Rojas Blum
- * @version March 31, 2018
+ * @version April 2, 2018
  */
 public class AuthorizeRestWebServiceHttpTest extends BaseTest {
 
@@ -2657,7 +2657,7 @@ public class AuthorizeRestWebServiceHttpTest extends BaseTest {
      * If a client has only openid scope and pairwise id, person should not have to authorize.
      */
     @Parameters({"userId", "userSecret", "redirectUris", "redirectUri", "sectorIdentifierUri"})
-    @Test
+    //@Test // Before run this test, set skipAuthorizationForOpenIdScopeAndPairwiseId = true
     public void requestAuthorizationForOpenIdScopeAndPairwiseId(
             final String userId, final String userSecret, final String redirectUris, final String redirectUri,
             final String sectorIdentifierUri) throws Exception {

--- a/Client/src/test/java/org/xdi/oxauth/ws/rs/MultivaluedClaims.java
+++ b/Client/src/test/java/org/xdi/oxauth/ws/rs/MultivaluedClaims.java
@@ -43,7 +43,7 @@ import static org.testng.Assert.*;
 
 /**
  * @author Javier Rojas Blum
- * @version October 26, 2017
+ * @version March 31, 2018
  */
 public class MultivaluedClaims extends BaseTest {
 
@@ -1417,7 +1417,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider();
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1513,7 +1513,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1610,7 +1610,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1707,7 +1707,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1805,7 +1805,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1908,7 +1908,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2011,7 +2011,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2114,7 +2114,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2217,7 +2217,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2320,7 +2320,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2422,7 +2422,7 @@ public class MultivaluedClaims extends BaseTest {
         String clientSecret = registerResponse.getClientSecret();
 
         // 2. Request authorization
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2520,7 +2520,7 @@ public class MultivaluedClaims extends BaseTest {
         String clientSecret = registerResponse.getClientSecret();
 
         // 2. Request authorization
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2630,7 +2630,7 @@ public class MultivaluedClaims extends BaseTest {
         JSONObject jwks = JwtUtil.getJSONWebKeys(jwksUri);
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2740,7 +2740,7 @@ public class MultivaluedClaims extends BaseTest {
         JSONObject jwks = JwtUtil.getJSONWebKeys(jwksUri);
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2850,7 +2850,7 @@ public class MultivaluedClaims extends BaseTest {
         JSONObject jwks = JwtUtil.getJSONWebKeys(jwksUri);
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid");
+        List<String> scopes = Arrays.asList("openid", "profile");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 

--- a/Client/src/test/java/org/xdi/oxauth/ws/rs/MultivaluedClaims.java
+++ b/Client/src/test/java/org/xdi/oxauth/ws/rs/MultivaluedClaims.java
@@ -43,7 +43,7 @@ import static org.testng.Assert.*;
 
 /**
  * @author Javier Rojas Blum
- * @version March 31, 2018
+ * @version April 2, 2018
  */
 public class MultivaluedClaims extends BaseTest {
 
@@ -1417,7 +1417,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider();
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1513,7 +1513,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1610,7 +1610,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1707,7 +1707,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1805,7 +1805,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -1908,7 +1908,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2011,7 +2011,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2114,7 +2114,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2217,7 +2217,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2320,7 +2320,7 @@ public class MultivaluedClaims extends BaseTest {
         // 2. Request authorization
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2422,7 +2422,7 @@ public class MultivaluedClaims extends BaseTest {
         String clientSecret = registerResponse.getClientSecret();
 
         // 2. Request authorization
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2520,7 +2520,7 @@ public class MultivaluedClaims extends BaseTest {
         String clientSecret = registerResponse.getClientSecret();
 
         // 2. Request authorization
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2630,7 +2630,7 @@ public class MultivaluedClaims extends BaseTest {
         JSONObject jwks = JwtUtil.getJSONWebKeys(jwksUri);
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2740,7 +2740,7 @@ public class MultivaluedClaims extends BaseTest {
         JSONObject jwks = JwtUtil.getJSONWebKeys(jwksUri);
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 
@@ -2850,7 +2850,7 @@ public class MultivaluedClaims extends BaseTest {
         JSONObject jwks = JwtUtil.getJSONWebKeys(jwksUri);
         OxAuthCryptoProvider cryptoProvider = new OxAuthCryptoProvider(keyStoreFile, keyStoreSecret, dnName);
 
-        List<String> scopes = Arrays.asList("openid", "profile");
+        List<String> scopes = Arrays.asList("openid");
         String nonce = UUID.randomUUID().toString();
         String state = UUID.randomUUID().toString();
 

--- a/Server/conf/oxauth-config.json
+++ b/Server/conf/oxauth-config.json
@@ -184,7 +184,7 @@
     "oxId":"https://${server.name}/oxid/service/gluu/inum",
     "dynamicRegistrationEnabled":true,
     "dynamicRegistrationExpirationTime":${config.client.dynamic-registration-expiration-time},
-    "dynamicRegistrationPersistClientAuthorizations":true,
+    "dynamicRegistrationPersistClientAuthorizations":false,
     "trustedClientEnabled":true,
     "skipAuthorizationForOpenIdScopeAndPairwiseId": true,
     "dynamicRegistrationScopesParamEnabled":true,


### PR DESCRIPTION
oxAuth #743
Add JSON property to enable admin to turn off authz for openid scope
If a client has only openid scope and pairwise id, person should not have to authorize.