### PR TITLE
Passport Issue 95 replace dot jwt auth z

### DIFF
--- a/Server/integrations/saml-passport/SamlPassportAuthenticator.py
+++ b/Server/integrations/saml-passport/SamlPassportAuthenticator.py
@@ -121,6 +121,9 @@ class PersonAuthentication(PersonAuthenticationType):
                 print "Entered if jwt_param != None"
                 print "Passport. authenticate for step 1. JWT user profile token found"
 
+                if self.isInboundFlow(identity):
+                    jwt_param = base64.urlsafe_b64decode(str(jwt_param+'=='))
+
                 # Parse JWT and validate
                 jwt = Jwt.parse(jwt_param)
 


### PR DESCRIPTION
This PR is related to issue  on gluu-passport: https://github.com/GluuFederation/gluu-passport/issues/95
and to gluu-passport PR: https://github.com/GluuFederation/gluu-passport/pull/97

For now, the inbound-saml script should receive and base64url encoded state.

Please do not merge PR during draft.

-  Here inbound-saml script also deals with the timer restart of external scripts.