### PR TITLE
Oidcc basic certification

### DIFF
--- a/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
+++ b/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
@@ -90,6 +90,7 @@ public class AppConfiguration implements Configuration {
     private Boolean claimsParameterSupported;
     private Boolean requestParameterSupported;
     private Boolean requestUriParameterSupported;
+    private Boolean requestUriHashVerificationEnabled;
     private Boolean requireRequestUriRegistration;
     private String opPolicyUri;
     private String opTosUri;
@@ -1908,5 +1909,13 @@ public class AppConfiguration implements Configuration {
 
     public void setCibaEnabled(Boolean cibaEnabled) {
         this.cibaEnabled = cibaEnabled;
+    }
+
+    public Boolean getRequestUriHashVerificationEnabled() {
+        return requestUriHashVerificationEnabled != null ? requestUriHashVerificationEnabled : false;
+    }
+
+    public void setRequestUriHashVerificationEnabled(Boolean requestUriHashVerificationEnabled) {
+        this.requestUriHashVerificationEnabled = requestUriHashVerificationEnabled;
     }
 }

--- a/Server/src/main/java/org/gluu/oxauth/model/authorize/JwtAuthorizationRequest.java
+++ b/Server/src/main/java/org/gluu/oxauth/model/authorize/JwtAuthorizationRequest.java
@@ -418,7 +418,8 @@ public class JwtAuthorizationRequest {
     }
 
     @Nullable
-    private static String queryRequest(@Nullable String requestUri, @Nullable RedirectUriResponse redirectUriResponse) {
+    private static String queryRequest(@Nullable String requestUri, @Nullable RedirectUriResponse redirectUriResponse,
+                                       AppConfiguration appConfiguration) {
         if (StringUtils.isBlank(requestUri)) {
             return null;
         }
@@ -438,7 +439,7 @@ public class JwtAuthorizationRequest {
             if (status == 200) {
                 request = clientResponse.getEntity(String.class);
 
-                if (StringUtils.isBlank(reqUriHash)) {
+                if (StringUtils.isBlank(reqUriHash) || !appConfiguration.getRequestUriHashVerificationEnabled()) {
                     validRequestUri = true;
                 } else {
                     String hash = Base64Util.base64urlencode(JwtUtil.getMessageDigestSHA256(request));
@@ -459,7 +460,7 @@ public class JwtAuthorizationRequest {
     }
 
     public static JwtAuthorizationRequest createJwtRequest(String request, String requestUri, Client client, RedirectUriResponse redirectUriResponse, AbstractCryptoProvider cryptoProvider, AppConfiguration appConfiguration) {
-        final String requestFromClient = queryRequest(requestUri, redirectUriResponse);
+        final String requestFromClient = queryRequest(requestUri, redirectUriResponse, appConfiguration);
         if (StringUtils.isNotBlank(requestFromClient)) {
             request = requestFromClient;
         }

--- a/Server/src/main/java/org/gluu/oxauth/userinfo/ws/rs/UserInfoRestWebServiceImpl.java
+++ b/Server/src/main/java/org/gluu/oxauth/userinfo/ws/rs/UserInfoRestWebServiceImpl.java
@@ -355,7 +355,7 @@ public class UserInfoRestWebServiceImpl implements UserInfoRestWebService {
                     } else if (value instanceof Boolean) {
                         jsonWebResponse.getClaims().setClaim(key, (Boolean) value);
                     } else if (value instanceof Date) {
-                        jsonWebResponse.getClaims().setClaim(key, ((Date) value).getTime());
+                        jsonWebResponse.getClaims().setClaim(key, ((Date) value).getTime() / 1000);
                     } else {
                         jsonWebResponse.getClaims().setClaim(key, String.valueOf(value));
                     }


### PR DESCRIPTION
Two small changes:
1. Use seconds instead of milliseconds in User Info response.
2. Add flag to enable/disable hash validation for `request_uri` param.

Test plan: https://www.certification.openid.net/plan-detail.html?plan=DF5fIFd6lr2rM&public=true

Jenkins build: https://ox.gluu.org/jenkins/job/oxAuth_master_LDAP/1219/

Issue: https://github.com/GluuFederation/oxAuth/issues/1429