### PR TITLE
Reverted Selenium dependencies

### DIFF
--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -205,8 +205,23 @@
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>htmlunit-driver</artifactId>
+            <artifactId>selenium-htmlunit-driver</artifactId>
             <scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-remote-driver</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-support</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.sourceforge.htmlunit</groupId>
+			<artifactId>htmlunit-cssparser</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -488,19 +488,31 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-java</artifactId>
-                <version>3.141.59</version>
+                <version>2.53.1</version>
                 <scope>test</scope>
             </dependency>
 			<dependency>
-				<groupId>net.sourceforge.htmlunit</groupId>
-				<artifactId>htmlunit</artifactId>
-				<version>2.35.0</version>
+				<groupId>org.seleniumhq.selenium</groupId>
+				<artifactId>selenium-remote-driver</artifactId>
+				<version>2.53.1</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.seleniumhq.selenium</groupId>
-				<artifactId>htmlunit-driver</artifactId>
-				<version>2.35.1</version>
+				<artifactId>selenium-support</artifactId>
+				<version>3.141.59</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>net.sourceforge.htmlunit</groupId>
+				<artifactId>htmlunit-cssparser</artifactId>
+				<version>1.5.0</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.seleniumhq.selenium</groupId>
+				<artifactId>selenium-htmlunit-driver</artifactId>
+				<version>2.52.0</version>
 				<scope>test</scope>
 			</dependency>
             <dependency>


### PR DESCRIPTION
After some tests I didn't find any issue using parallel feature, failed tests were related to disk space stuff, therefore I think we are ready to revert Selenium dependencies.

Last Jenkins build: https://ox.gluu.org/jenkins/job/oxAuth_master_LDAP/1401/