### PR TITLE
#553 - Change `client_frontchannel_logout_uri` from `List` to `string`  type during client registration

### DIFF
--- a/Client/src/main/java/org/gluu/oxauth/client/RegisterClient.java
+++ b/Client/src/main/java/org/gluu/oxauth/client/RegisterClient.java
@@ -219,8 +219,8 @@ public class RegisterClient extends BaseClient<RegisterRequest, RegisterResponse
                 if (getRequest().getPostLogoutRedirectUris() != null && !getRequest().getPostLogoutRedirectUris().isEmpty()) {
                     requestBody.put(POST_LOGOUT_REDIRECT_URIS.toString(), getRequest().getPostLogoutRedirectUris());
                 }
-                if (getRequest().getFrontChannelLogoutUris() != null && !getRequest().getFrontChannelLogoutUris().isEmpty()) {
-                    requestBody.put(FRONT_CHANNEL_LOGOUT_URI.getName(), getRequest().getFrontChannelLogoutUris());
+                if (StringUtils.isNotBlank(getRequest().getFrontChannelLogoutUri())) {
+                    requestBody.put(FRONT_CHANNEL_LOGOUT_URI.getName(), getRequest().getFrontChannelLogoutUri());
                 }
                 if (getRequest().getFrontChannelLogoutSessionRequired() != null) {
                     requestBody.put(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.getName(), getRequest().getFrontChannelLogoutSessionRequired());

--- a/Client/src/main/java/org/gluu/oxauth/client/RegisterRequest.java
+++ b/Client/src/main/java/org/gluu/oxauth/client/RegisterRequest.java
@@ -64,7 +64,7 @@ public class RegisterRequest extends BaseRequest {
     private String logoUri;
     private String clientUri;
     private String policyUri;
-    private List<String> frontChannelLogoutUris;
+    private String frontChannelLogoutUri;
     private Boolean frontChannelLogoutSessionRequired;
     private List<String> backchannelLogoutUris;
     private Boolean backchannelLogoutSessionRequired;
@@ -265,17 +265,17 @@ public class RegisterRequest extends BaseRequest {
      *
      * @return logout uri
      */
-    public List<String> getFrontChannelLogoutUris() {
-        return frontChannelLogoutUris;
+    public String getFrontChannelLogoutUri() {
+        return frontChannelLogoutUri;
     }
 
     /**
      * Sets logout uri
      *
-     * @param logoutUris logout uri
+     * @param logoutUri logout uri
      */
-    public void setFrontChannelLogoutUris(List<String> logoutUris) {
-        this.frontChannelLogoutUris = logoutUris;
+    public void setFrontChannelLogoutUri(String logoutUri) {
+        this.frontChannelLogoutUri = logoutUri;
     }
 
     /**
@@ -1252,8 +1252,8 @@ public class RegisterRequest extends BaseRequest {
         if (postLogoutRedirectUris != null && !postLogoutRedirectUris.isEmpty()) {
             parameters.put(POST_LOGOUT_REDIRECT_URIS.toString(), toJSONArray(postLogoutRedirectUris).toString());
         }
-        if (frontChannelLogoutUris != null && !frontChannelLogoutUris.isEmpty()) {
-            parameters.put(FRONT_CHANNEL_LOGOUT_URI.toString(), toJSONArray(frontChannelLogoutUris).toString());
+        if (StringUtils.isNotBlank(frontChannelLogoutUri)) {
+            parameters.put(FRONT_CHANNEL_LOGOUT_URI.toString(), frontChannelLogoutUri);
         }
         if (frontChannelLogoutSessionRequired != null) {
             parameters.put(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString(), frontChannelLogoutSessionRequired.toString());
@@ -1457,7 +1457,7 @@ public class RegisterRequest extends BaseRequest {
         result.setPostLogoutRedirectUris(postLogoutRedirectUris);
         result.setDefaultAcrValues(defaultAcrValues);
         result.setRequireAuthTime(requestObject.has(REQUIRE_AUTH_TIME.toString()) && requestObject.getBoolean(REQUIRE_AUTH_TIME.toString()));
-        result.setFrontChannelLogoutUris(extractList(requestObject, FRONT_CHANNEL_LOGOUT_URI.toString()));
+        result.setFrontChannelLogoutUri(requestObject.optString(FRONT_CHANNEL_LOGOUT_URI.toString()));
         result.setFrontChannelLogoutSessionRequired(requestObject.optBoolean(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString()));
         result.setBackchannelLogoutUris(extractList(requestObject, BACKCHANNEL_LOGOUT_URI.toString()));
         result.setBackchannelLogoutSessionRequired(requestObject.optBoolean(BACKCHANNEL_LOGOUT_SESSION_REQUIRED.toString()));
@@ -1670,8 +1670,8 @@ public class RegisterRequest extends BaseRequest {
         if (postLogoutRedirectUris != null && !postLogoutRedirectUris.isEmpty()) {
             parameters.put(POST_LOGOUT_REDIRECT_URIS.toString(), toJSONArray(postLogoutRedirectUris));
         }
-        if (frontChannelLogoutUris != null && !frontChannelLogoutUris.isEmpty()) {
-            parameters.put(FRONT_CHANNEL_LOGOUT_URI.toString(), toJSONArray(frontChannelLogoutUris));
+        if (StringUtils.isNotBlank(frontChannelLogoutUri)) {
+            parameters.put(FRONT_CHANNEL_LOGOUT_URI.toString(), frontChannelLogoutUri);
         }
         if (frontChannelLogoutSessionRequired != null) {
             parameters.put(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString(), frontChannelLogoutSessionRequired.toString());

--- a/Client/src/test/java/org/gluu/oxauth/ws/rs/EndSessionRestWebServiceHttpTest.java
+++ b/Client/src/test/java/org/gluu/oxauth/ws/rs/EndSessionRestWebServiceHttpTest.java
@@ -46,7 +46,7 @@ public class EndSessionRestWebServiceHttpTest extends BaseTest {
                 StringUtils.spaceSeparatedToList(redirectUris));
         registerRequest.setResponseTypes(Arrays.asList(ResponseType.TOKEN, ResponseType.ID_TOKEN));
         registerRequest.setPostLogoutRedirectUris(Arrays.asList(postLogoutRedirectUri));
-        registerRequest.setFrontChannelLogoutUris(Lists.newArrayList(logoutUri));
+        registerRequest.setFrontChannelLogoutUri(logoutUri);
         registerRequest.setSectorIdentifierUri(sectorIdentifierUri);
 
         RegisterClient registerClient = new RegisterClient(registrationEndpoint);
@@ -141,7 +141,7 @@ public class EndSessionRestWebServiceHttpTest extends BaseTest {
                 StringUtils.spaceSeparatedToList(redirectUris));
         registerRequest.setResponseTypes(Arrays.asList(ResponseType.TOKEN, ResponseType.ID_TOKEN));
         registerRequest.setPostLogoutRedirectUris(Arrays.asList(postLogoutRedirectUri));
-        registerRequest.setFrontChannelLogoutUris(Lists.newArrayList(logoutUri));
+        registerRequest.setFrontChannelLogoutUri(logoutUri);
         registerRequest.setSectorIdentifierUri(sectorIdentifierUri);
 
         RegisterClient registerClient = new RegisterClient(registrationEndpoint);

--- a/Client/src/test/java/org/gluu/oxauth/ws/rs/GrantTypesRestrictionHttpTest.java
+++ b/Client/src/test/java/org/gluu/oxauth/ws/rs/GrantTypesRestrictionHttpTest.java
@@ -60,7 +60,7 @@ public class GrantTypesRestrictionHttpTest extends BaseTest {
         registerRequest.setSubjectType(SubjectType.PAIRWISE);
         registerRequest.setSectorIdentifierUri(sectorIdentifierUri);
         registerRequest.setPostLogoutRedirectUris(Arrays.asList(postLogoutRedirectUri));
-        registerRequest.setFrontChannelLogoutUris(Lists.newArrayList(logoutUri));
+        registerRequest.setFrontChannelLogoutUri(logoutUri);
 
         RegisterClient registerClient = new RegisterClient(registrationEndpoint);
         registerClient.setRequest(registerRequest);

--- a/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationRestWebServiceHttpTest.java
+++ b/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationRestWebServiceHttpTest.java
@@ -148,7 +148,7 @@ public class RegistrationRestWebServiceHttpTest extends BaseTest {
         registerRequest.setSectorIdentifierUri(sectorIdentifierUri);
         registerRequest.setSubjectType(SubjectType.PAIRWISE);
         registerRequest.setRequestUris(Arrays.asList("http://www.gluu.org/request"));
-        registerRequest.setFrontChannelLogoutUris(Lists.newArrayList(logoutUri));
+        registerRequest.setFrontChannelLogoutUri(logoutUri);
         registerRequest.setFrontChannelLogoutSessionRequired(true);
         registerRequest.setBackchannelLogoutUris(Lists.newArrayList(logoutUri));
         registerRequest.setBackchannelLogoutSessionRequired(true);

--- a/RP/src/main/java/org/gluu/oxauth/action/RegistrationAction.java
+++ b/RP/src/main/java/org/gluu/oxauth/action/RegistrationAction.java
@@ -152,7 +152,7 @@ public class RegistrationAction implements Serializable {
             request.setInitiateLoginUri(initiateLoginUri);
             request.setPostLogoutRedirectUris(StringUtils.spaceSeparatedToList(postLogoutRedirectUris));
             request.setRequestUris(StringUtils.spaceSeparatedToList(requestUris));
-            request.setFrontChannelLogoutUris(Lists.newArrayList(logoutUri));
+            request.setFrontChannelLogoutUri(logoutUri);
             request.setFrontChannelLogoutSessionRequired(logoutSessionRequired);
 
             // CIBA

--- a/Server/src/main/java/org/gluu/oxauth/register/ws/rs/RegisterRestWebServiceImpl.java
+++ b/Server/src/main/java/org/gluu/oxauth/register/ws/rs/RegisterRestWebServiceImpl.java
@@ -241,7 +241,7 @@ public class RegisterRestWebServiceImpl implements RegisterRestWebService {
             }
 
 
-            registerParamsValidator.validateLogoutUri(r.getFrontChannelLogoutUris(), r.getRedirectUris(), errorResponseFactory);
+            registerParamsValidator.validateLogoutUri(r.getFrontChannelLogoutUri(), r.getRedirectUris(), errorResponseFactory);
             registerParamsValidator.validateLogoutUri(r.getBackchannelLogoutUris(), r.getRedirectUris(), errorResponseFactory);
 
             String clientsBaseDN = staticConfiguration.getBaseDn().getClients();
@@ -607,8 +607,8 @@ public class RegisterRestWebServiceImpl implements RegisterRestWebService {
             p_client.setPostLogoutRedirectUris(postLogoutRedirectUris.toArray(new String[postLogoutRedirectUris.size()]));
         }
 
-        if (requestObject.getFrontChannelLogoutUris() != null && !requestObject.getFrontChannelLogoutUris().isEmpty()) {
-            p_client.setFrontChannelLogoutUri(requestObject.getFrontChannelLogoutUris().toArray(new String[requestObject.getFrontChannelLogoutUris().size()]));
+        if (StringUtils.isNotBlank(requestObject.getFrontChannelLogoutUri())) {
+            p_client.setFrontChannelLogoutUri(new String[]{requestObject.getFrontChannelLogoutUri()});
         }
         p_client.setFrontChannelLogoutSessionRequired(requestObject.getFrontChannelLogoutSessionRequired());
 

--- a/Server/src/test/java/org/gluu/oxauth/ws/rs/EndSessionRestWebServiceEmbeddedTest.java
+++ b/Server/src/test/java/org/gluu/oxauth/ws/rs/EndSessionRestWebServiceEmbeddedTest.java
@@ -74,7 +74,7 @@ public class EndSessionRestWebServiceEmbeddedTest extends BaseTest {
                     StringUtils.spaceSeparatedToList(redirectUris));
             registerRequest.setResponseTypes(Arrays.asList(ResponseType.TOKEN, ResponseType.ID_TOKEN));
             registerRequest.setPostLogoutRedirectUris(Arrays.asList(postLogoutRedirectUri));
-            registerRequest.setFrontChannelLogoutUris(Lists.newArrayList(postLogoutRedirectUri));
+            registerRequest.setFrontChannelLogoutUri(postLogoutRedirectUri);
             registerRequest.addCustomAttribute("oxAuthTrustedClient", "true");
 
             registerRequestContent = ServerUtil.toPrettyJson(registerRequest.getJSONParameters());


### PR DESCRIPTION
#553 - Change `client_frontchannel_logout_uri` from `List` to `string`  type during client registration
https://github.com/GluuFederation/oxd/issues/553