### PR TITLE
Issue#553 - Change `client_frontchannel_logout_uri` from `List` to `string` type during client registration

### DIFF
--- a/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationRestWebServiceHttpTest.java
+++ b/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationRestWebServiceHttpTest.java
@@ -181,7 +181,7 @@ public class RegistrationRestWebServiceHttpTest extends BaseTest {
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString()));
         assertTrue(Boolean.parseBoolean(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString())));
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
-        assertEquals(logoutUri, new JSONArray(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString())).getString(0));
+        assertEquals(logoutUri, response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
         assertNotNull(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString()));
         assertEquals(SignatureAlgorithm.RS512,
                 SignatureAlgorithm.fromString(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString())));

--- a/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationWithSoftwareStatement.java
+++ b/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationWithSoftwareStatement.java
@@ -107,7 +107,7 @@ public class RegistrationWithSoftwareStatement extends BaseTest {
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString()));
         assertTrue(Boolean.parseBoolean(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString())));
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
-        assertTrue(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()).equals(logoutUri));
+        assertEquals(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()), logoutUri);
         assertNotNull(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString()));
         assertEquals(SignatureAlgorithm.RS512,
                 SignatureAlgorithm.fromString(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString())));
@@ -226,7 +226,7 @@ public class RegistrationWithSoftwareStatement extends BaseTest {
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString()));
         assertTrue(Boolean.parseBoolean(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString())));
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
-        assertTrue(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()).equals(logoutUri));
+        assertEquals(logoutUri, response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
         assertNotNull(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString()));
         assertEquals(SignatureAlgorithm.RS512,
                 SignatureAlgorithm.fromString(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString())));

--- a/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationWithSoftwareStatement.java
+++ b/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationWithSoftwareStatement.java
@@ -107,7 +107,7 @@ public class RegistrationWithSoftwareStatement extends BaseTest {
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString()));
         assertTrue(Boolean.parseBoolean(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString())));
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
-        assertEquals(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()), logoutUri);
+        assertTrue(new JSONArray(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString())).getString(0).equals(logoutUri));
         assertNotNull(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString()));
         assertEquals(SignatureAlgorithm.RS512,
                 SignatureAlgorithm.fromString(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString())));
@@ -226,7 +226,7 @@ public class RegistrationWithSoftwareStatement extends BaseTest {
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString()));
         assertTrue(Boolean.parseBoolean(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString())));
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
-        assertEquals(logoutUri, response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
+        assertTrue(new JSONArray(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString())).getString(0).equals(logoutUri));
         assertNotNull(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString()));
         assertEquals(SignatureAlgorithm.RS512,
                 SignatureAlgorithm.fromString(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString())));

--- a/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationWithSoftwareStatement.java
+++ b/Client/src/test/java/org/gluu/oxauth/ws/rs/RegistrationWithSoftwareStatement.java
@@ -107,7 +107,7 @@ public class RegistrationWithSoftwareStatement extends BaseTest {
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString()));
         assertTrue(Boolean.parseBoolean(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString())));
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
-        assertTrue(new JSONArray(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString())).getString(0).equals(logoutUri));
+        assertTrue(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()).equals(logoutUri));
         assertNotNull(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString()));
         assertEquals(SignatureAlgorithm.RS512,
                 SignatureAlgorithm.fromString(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString())));
@@ -226,7 +226,7 @@ public class RegistrationWithSoftwareStatement extends BaseTest {
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString()));
         assertTrue(Boolean.parseBoolean(response.getClaims().get(FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED.toString())));
         assertNotNull(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()));
-        assertTrue(new JSONArray(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString())).getString(0).equals(logoutUri));
+        assertTrue(response.getClaims().get(FRONT_CHANNEL_LOGOUT_URI.toString()).equals(logoutUri));
         assertNotNull(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString()));
         assertEquals(SignatureAlgorithm.RS512,
                 SignatureAlgorithm.fromString(response.getClaims().get(ID_TOKEN_SIGNED_RESPONSE_ALG.toString())));

--- a/Server/src/main/java/org/gluu/oxauth/register/ws/rs/RegisterRestWebServiceImpl.java
+++ b/Server/src/main/java/org/gluu/oxauth/register/ws/rs/RegisterRestWebServiceImpl.java
@@ -608,7 +608,7 @@ public class RegisterRestWebServiceImpl implements RegisterRestWebService {
         }
 
         if (StringUtils.isNotBlank(requestObject.getFrontChannelLogoutUri())) {
-            p_client.setFrontChannelLogoutUri(new String[]{requestObject.getFrontChannelLogoutUri()});
+            p_client.setFrontChannelLogoutUri(requestObject.getFrontChannelLogoutUri());
         }
         p_client.setFrontChannelLogoutSessionRequired(requestObject.getFrontChannelLogoutSessionRequired());
 

--- a/Server/src/main/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImpl.java
+++ b/Server/src/main/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImpl.java
@@ -145,9 +145,12 @@ public class EndSessionRestWebServiceImpl implements EndSessionRestWebService {
                 if (hasBackchannel) { // client has backchannel_logout_uri
                     continue;
                 }
-
                 if(StringUtils.isNotBlank(client.getFrontChannelLogoutUri())) {
-                    frontchannelUris.add(EndSessionUtils.appendSid(client.getFrontChannelLogoutUri(), pair.getFirst().getOutsideSid(), appConfiguration.getIssuer()));
+                    String logoutUri = client.getFrontChannelLogoutUri();
+                    if (client.getFrontChannelLogoutSessionRequired()) {
+                        logoutUri = EndSessionUtils.appendSid(logoutUri, pair.getFirst().getOutsideSid(), appConfiguration.getIssuer());
+                    }
+                    frontchannelUris.add(logoutUri);
                 }
             }
 

--- a/Server/src/main/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImpl.java
+++ b/Server/src/main/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImpl.java
@@ -146,15 +146,8 @@ public class EndSessionRestWebServiceImpl implements EndSessionRestWebService {
                     continue;
                 }
 
-                for (String logoutUri : client.getFrontChannelLogoutUri()) {
-                    if (Util.isNullOrEmpty(logoutUri)) {
-                        continue; // skip if logout_uri is blank
-                    }
-
-                    if (client.getFrontChannelLogoutSessionRequired()) {
-                        logoutUri = EndSessionUtils.appendSid(logoutUri, pair.getFirst().getOutsideSid(), appConfiguration.getIssuer());
-                    }
-                    frontchannelUris.add(logoutUri);
+                if(StringUtils.isNotBlank(client.getFrontChannelLogoutUri())) {
+                    frontchannelUris.add(EndSessionUtils.appendSid(client.getFrontChannelLogoutUri(), pair.getFirst().getOutsideSid(), appConfiguration.getIssuer()));
                 }
             }
 

--- a/common/src/main/java/org/gluu/oxauth/model/registration/Client.java
+++ b/common/src/main/java/org/gluu/oxauth/model/registration/Client.java
@@ -17,9 +17,6 @@ import org.gluu.persist.model.base.CustomAttribute;
 import org.gluu.persist.model.base.DeletableEntity;
 import org.oxauth.persistence.model.ClientAttributes;
 
-import javax.persistence.Transient;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -47,7 +44,7 @@ public class Client extends DeletableEntity implements Serializable {
     private String clientSecret;
 
     @AttributeName(name = "oxAuthLogoutURI")
-    private String[] frontChannelLogoutUri;
+    private String frontChannelLogoutUri;
 
     @AttributeName(name = "oxAuthLogoutSessionRequired")
     private Boolean frontChannelLogoutSessionRequired;
@@ -315,8 +312,7 @@ public class Client extends DeletableEntity implements Serializable {
      *
      * @return logout uri
      */
-    public String[] getFrontChannelLogoutUri() {
-        if (frontChannelLogoutUri == null) frontChannelLogoutUri = new String[0];
+    public String getFrontChannelLogoutUri() {
         return frontChannelLogoutUri;
     }
 
@@ -325,7 +321,7 @@ public class Client extends DeletableEntity implements Serializable {
      *
      * @param frontChannelLogoutUri logout uri
      */
-    public void setFrontChannelLogoutUri(String[] frontChannelLogoutUri) {
+    public void setFrontChannelLogoutUri(String frontChannelLogoutUri) {
         this.frontChannelLogoutUri = frontChannelLogoutUri;
     }
 


### PR DESCRIPTION
Issue#553 - Change `client_frontchannel_logout_uri` from `List` to `string` type during client registration
https://github.com/GluuFederation/oxd/issues/553

Changed `common/src/main/java/org/gluu/oxauth/model/registration/Client.frontChannelLogoutUri` from `String[]` to `Sting` to correct the test cases