### PR TITLE
#1056 Modify the `claims-gathering` script so that it first tries to read claims from PCT before directing to the page to enter claims.

### DIFF
--- a/Server/src/main/webapp/uma2/sample/claims_resolved.xhtml
+++ b/Server/src/main/webapp/uma2/sample/claims_resolved.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                template="/WEB-INF/incl/layout/template.xhtml">
+
+    <f:metadata>
+        <f:viewAction action="#{gatherer.prepareForStep}"/>
+    </f:metadata>
+
+    <ui:define name="head">
+        <style type="text/css">
+        </style>
+    </ui:define>
+
+    <ui:define name="pageTitle" style="font-weight:bold">Claims Resolved</ui:define>
+
+    <ui:define name="body">
+        <h:outputLabel for="claimsResolved" style="font-weight:bold" value="All Claims Resolved from previous RPT authorization"/><br/>
+        <h:form id="loginForm">
+            <div class="actionButtons">
+                <h:commandButton id="gather" value="Proceed" action="#{gatherer.gather}"/>
+            </div>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/Server/uma/sample/UmaClaimsGathering.py
+++ b/Server/uma/sample/UmaClaimsGathering.py
@@ -34,6 +34,9 @@ class UmaClaimsGathering(UmaClaimsGatheringType):
     def gather(self, step, context): # context is reference of org.gluu.oxauth.uma.authorization.UmaGatherContext
         print "Claims-Gathering. Gathering ..."
 
+        if context.getClaim("country") == 'US' and context.getClaim("city") == 'NY':
+            return True
+
         if step == 1:
             if (context.getPageClaims().containsKey("country")):
                 country = context.getPageClaims().get("country")
@@ -90,14 +93,27 @@ class UmaClaimsGathering(UmaClaimsGatheringType):
         print "Trying to get claims from PCT ..."
         pctCode = context.getRequestParameters().get("pct")
         if pctCode is not None:
-            pct = CdiUtil.bean(UmaPctService).getByCode(pctCode[0])
-            country = pct.getClaims().getClaimAsString("country")
-            print "Country from pct: " + country
-            city = pct.getClaims().getClaimAsString("city")
-            print "City from pct: " + city
+            try:
+                pct = CdiUtil.bean(UmaPctService).getByCode(pctCode[0])
 
-            if country == 'US' and city == 'NY':
-                return ""
+                country = pct.getClaims().getClaimAsString("country")
+                print "Country from pct: " + country
+                context.putClaim("country", country)
+
+                city = pct.getClaims().getClaimAsString("city")
+                print "City from pct: " + city
+                context.putClaim("city", city)
+
+                stepsCount = 2
+                print "stepsCount: " + str(stepsCount)
+                for x in range(1, stepsCount):
+                    context.addSessionAttribute("uma_step_passed_" + str(x), str(True))
+                context.setStep(stepsCount)
+
+                return "/uma2/sample/claims_resolved.xhtml"
+            except:
+                print "Exception occured. Unable to resolve pct from client."
+
 
         print "Claims not found in pct ..."
         if step == 1:


### PR DESCRIPTION
If `pct` is passed by client in request and claims are found in `pct` it will redirect to `claims_resolved.xhtml` page showing message `All Claims Resolved from previous RPT authorization`. On click of proceed button it will go to the upstream application.