### PR TITLE
Update Cas2DuoExternalAuthenticator.py

### DIFF
--- a/Server/integrations/cas2_duo/Cas2DuoExternalAuthenticator.py
+++ b/Server/integrations/cas2_duo/Cas2DuoExternalAuthenticator.py
@@ -24,8 +24,8 @@ class PersonAuthentication(PersonAuthenticationType):
     def init(self, customScript, configurationAttributes):
         print "CAS2 + Duo. Initialization"
         
-        cas2_result = self.cas2ExternalAuthenticator.init(configurationAttributes)
-        duo_result = self.duoExternalAuthenticator.init(configurationAttributes)
+        cas2_result = self.cas2ExternalAuthenticator.init(customScript, configurationAttributes)
+        duo_result = self.duoExternalAuthenticator.init(customScript, configurationAttributes)
 
         print "CAS2 + Duo. Initialized successfully"
 


### PR DESCRIPTION
commit 528f933a8bf55b272fb6d78af1f93115fbf47060 did not include the required updates for the two subordinate authentication methods.