### PR TITLE
Fix: fixed resteasy response init for CIBA classes

### DIFF
--- a/Client/src/main/java/org/gluu/oxauth/client/ciba/fcm/FirebaseCloudMessagingResponse.java
+++ b/Client/src/main/java/org/gluu/oxauth/client/ciba/fcm/FirebaseCloudMessagingResponse.java
@@ -39,10 +39,6 @@ public class FirebaseCloudMessagingResponse extends BaseResponse {
 
     public FirebaseCloudMessagingResponse(Response clientResponse) {
         super(clientResponse);
-
-        String entity = clientResponse.readEntity(String.class);
-        setEntity(entity);
-        setHeaders(clientResponse.getMetadata());
         injectDataFromJson(entity);
     }
 

--- a/Client/src/main/java/org/gluu/oxauth/client/ciba/ping/PingCallbackResponse.java
+++ b/Client/src/main/java/org/gluu/oxauth/client/ciba/ping/PingCallbackResponse.java
@@ -21,9 +21,5 @@ public class PingCallbackResponse extends BaseResponse {
 
     public PingCallbackResponse(Response clientResponse) {
         super(clientResponse);
-
-        String entity = clientResponse.readEntity(String.class);
-        setEntity(entity);
-        setHeaders(clientResponse.getMetadata());
     }
 }

--- a/Client/src/main/java/org/gluu/oxauth/client/ciba/push/PushErrorResponse.java
+++ b/Client/src/main/java/org/gluu/oxauth/client/ciba/push/PushErrorResponse.java
@@ -21,9 +21,5 @@ public class PushErrorResponse extends BaseResponse {
 
     public PushErrorResponse(Response clientResponse) {
         super(clientResponse);
-
-        String entity = clientResponse.readEntity(String.class);
-        setEntity(entity);
-        setHeaders(clientResponse.getMetadata());
     }
 }

--- a/Client/src/main/java/org/gluu/oxauth/client/ciba/push/PushTokenDeliveryResponse.java
+++ b/Client/src/main/java/org/gluu/oxauth/client/ciba/push/PushTokenDeliveryResponse.java
@@ -21,9 +21,5 @@ public class PushTokenDeliveryResponse extends BaseResponse {
 
     public PushTokenDeliveryResponse(Response clientResponse) {
         super(clientResponse);
-
-        String entity = clientResponse.readEntity(String.class);
-        setEntity(entity);
-        setHeaders(clientResponse.getMetadata());
     }
 }


### PR DESCRIPTION
During RESTEasy lib update, an issue was introduced, client response classes were initialized incorrectly, enforcing response instance to be loaded twice, so it lead into this issue:
```
IllegalStateException is thrown with the following message RESTEASY003765: Response is closed.
```