### PR TITLE
fix(oxauth): reduce noise in logs when session can't be found #1646

### DIFF
--- a/Server/src/main/java/org/gluu/oxauth/service/SessionIdService.java
+++ b/Server/src/main/java/org/gluu/oxauth/service/SessionIdService.java
@@ -828,7 +828,7 @@ public class SessionIdService {
             }
         } catch (Exception ex) {
             if (!silently) {
-                log.trace(ex.getMessage(), ex);
+                log.trace(ex.getMessage());
             }
         }
 


### PR DESCRIPTION
Print message without stack trace.

https://github.com/GluuFederation/oxAuth/issues/1646