### PR TITLE
Fix / include idtoken with dynamic scopes for ciba

### DIFF
--- a/Server/src/main/java/org/gluu/oxauth/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/Server/src/main/java/org/gluu/oxauth/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -673,9 +673,10 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
         ExternalUpdateTokenContext context = new ExternalUpdateTokenContext(httpRequest, cibaGrant, client, appConfiguration, attributeService);
         Function<JsonWebResponse, Void> postProcessor = externalUpdateTokenService.buildModifyIdTokenProcessor(context);
 
+        boolean includeIdTokenClaims = Boolean.TRUE.equals(appConfiguration.getLegacyIdTokenClaims());
         IdToken idToken = cibaGrant.createIdToken(
                 null, null, accessToken, refreshToken,
-                null, cibaGrant, false, null, postProcessor);
+                null, cibaGrant, includeIdTokenClaims, null, postProcessor);
 
         cibaGrant.setTokensDelivered(true);
         cibaGrant.save();

--- a/Server/src/main/java/org/gluu/oxauth/token/ws/rs/TokenRestWebServiceImpl.java
+++ b/Server/src/main/java/org/gluu/oxauth/token/ws/rs/TokenRestWebServiceImpl.java
@@ -453,9 +453,10 @@ public class TokenRestWebServiceImpl implements TokenRestWebService {
                             ExternalUpdateTokenContext context = new ExternalUpdateTokenContext(request, cibaGrant, client, appConfiguration, attributeService);
                             Function<JsonWebResponse, Void> postProcessor = externalUpdateTokenService.buildModifyIdTokenProcessor(context);
 
+                            boolean includeIdTokenClaims = Boolean.TRUE.equals(appConfiguration.getLegacyIdTokenClaims());
                             IdToken idToken = cibaGrant.createIdToken(
                                     null, null, accessToken, refToken,
-                                    null, cibaGrant, false, null, postProcessor);
+                                    null, cibaGrant, includeIdTokenClaims, null, postProcessor);
 
                             cibaGrant.setTokensDelivered(true);
                             cibaGrant.save();
@@ -580,9 +581,10 @@ public class TokenRestWebServiceImpl implements TokenRestWebService {
             ExternalUpdateTokenContext context = new ExternalUpdateTokenContext(request, deviceCodeGrant, client, appConfiguration, attributeService);
             Function<JsonWebResponse, Void> postProcessor = externalUpdateTokenService.buildModifyIdTokenProcessor(context);
 
+            boolean includeIdTokenClaims = Boolean.TRUE.equals(appConfiguration.getLegacyIdTokenClaims());
             IdToken idToken = deviceCodeGrant.createIdToken(
                     null, null, accessToken, refToken,
-                    null, deviceCodeGrant, false, null, postProcessor);
+                    null, deviceCodeGrant, includeIdTokenClaims, null, postProcessor);
 
             RefreshToken reToken = null;
             if (isRefreshTokenAllowed(client, scope, deviceCodeGrant)) {


### PR DESCRIPTION
From a support ticket, we found that we need to include dynamic scopes as part of idToken generation for CIBA grant type.

Issue: https://github.com/GluuFederation/oxAuth/issues/1701