### PR TITLE
Fix german translation in oxauth_de.properties

### DIFF
--- a/Server/src/main/resources/oxauth_de.properties
+++ b/Server/src/main/resources/oxauth_de.properties
@@ -3,19 +3,19 @@ down=\u2193
 left=\u2039
 right=\u203A
 
-login.pageTitle=oxAuth - Inicio de sesi\u00F3n
-login.login=Inicio de sesi\u00F3n
-login.pleaseLoginHere=Ingrese los datos de su cuenta para iniciar sesi\u00F3n
-login.username=Nombre de usuario
-login.password=Contrase\u00F1a
-login.rememberMe=Recordar mis datos
-login.errorMessage=Ingrese un nombre de usuario y password validos
-login.failedToAuthenticate=Failed to authenticate.
-login.youDontHavePermission=You don't have permissions.
-login.forgotYourPassword = Forgot your password?
+login.pageTitle=oxAuth - Anmeldung
+login.login=Anmelden
+login.pleaseLoginHere=Bitte hier anmelden
+login.username=Benutzername
+login.password=Passwort
+login.rememberMe=Anmeldedaten speichern
+login.errorMessage=Falscher Benutzername oder falsches Passwort.
+login.failedToAuthenticate=Authentifizierung fehlgeschlagen
+login.youDontHavePermission=Sie haben keine Berechtigung.
+login.forgotYourPassword=Passwort vergessen?
 
-logout.missingParameters=Invalid Request. The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.
-logout.failedToProceed=Failed to process logout
+logout.missingParameters=Ung\u00FCltige Anfrage. Ein erforderlicher Parameter fehlt, ist nicht unterstg\u00FCtzt oder die Anfrage ist anderweitig fehlerhaft.
+logout.failedToProceed=Abmeldung kann nicht verarbeitet werden
 
 validator.assertFalse=Validierung fehlgeschlagen
 validator.assertTrue=Validierung fehlgeschlagen


### PR DESCRIPTION
Some translation in the file oxauth_de.properties is in Spanish or English. Changed it to German, otherwise the browser shows the wrong language, if default language is German. See also this [support question](https://support.gluu.org/identity-management/8955/login-site-shows-wrong-language/)

Please verify and merge on occasion