### PR TITLE
feat(oxauth): allow authentication for max_age=0 #1714

### DIFF
--- a/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
+++ b/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
@@ -241,6 +241,7 @@ public class AppConfiguration implements Configuration {
     private ErrorHandlingMethod errorHandlingMethod = ErrorHandlingMethod.INTERNAL;
 
     private Boolean keepAuthenticatorAttributesOnAcrChange = false;
+    private Boolean disableAuthnForMaxAgeZero = false;
     private int deviceAuthzRequestExpiresIn;
     private int deviceAuthzTokenPollInterval;
     private String deviceAuthzResponseTypeToProcessAuthz;
@@ -1866,7 +1867,15 @@ public class AppConfiguration implements Configuration {
 		this.keepAuthenticatorAttributesOnAcrChange = keepAuthenticatorAttributesOnAcrChange;
 	}
 
-	public String getBackchannelClientId() {
+    public Boolean getDisableAuthnForMaxAgeZero() {
+        return disableAuthnForMaxAgeZero;
+    }
+
+    public void setDisableAuthnForMaxAgeZero(Boolean disableAuthnForMaxAgeZero) {
+        this.disableAuthnForMaxAgeZero = disableAuthnForMaxAgeZero;
+    }
+
+    public String getBackchannelClientId() {
         return backchannelClientId;
     }
 

--- a/Server/src/main/java/org/gluu/oxauth/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/Server/src/main/java/org/gluu/oxauth/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -406,8 +406,8 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
                 }
             }
 
-            boolean validAuthenticationMaxAge = authorizeRestWebServiceValidator.validateAuthnMaxAge(maxAge, sessionUser, client);
-            if (!validAuthenticationMaxAge) {
+            boolean authnMaxAgeValid = authorizeRestWebServiceValidator.isAuthnMaxAgeValid(maxAge, sessionUser, client);
+            if (!authnMaxAgeValid) {
                 unauthenticateSession(sessionId, httpRequest);
                 sessionId = null;
 

--- a/Server/src/test/java/org/gluu/oxauth/authorize/ws/rs/AuthorizeRestWebServiceValidatorTest.java
+++ b/Server/src/test/java/org/gluu/oxauth/authorize/ws/rs/AuthorizeRestWebServiceValidatorTest.java
@@ -1,0 +1,77 @@
+package org.gluu.oxauth.authorize.ws.rs;
+
+import org.gluu.oxauth.model.common.SessionId;
+import org.gluu.oxauth.model.configuration.AppConfiguration;
+import org.gluu.oxauth.model.error.ErrorResponseFactory;
+import org.gluu.oxauth.model.registration.Client;
+import org.gluu.oxauth.security.Identity;
+import org.gluu.oxauth.service.ClientService;
+import org.gluu.oxauth.service.DeviceAuthorizationService;
+import org.gluu.oxauth.service.RedirectionUriService;
+import org.gluu.oxauth.service.SessionIdService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class AuthorizeRestWebServiceValidatorTest {
+
+    @InjectMocks
+    private AuthorizeRestWebServiceValidator authorizeRestWebServiceValidator;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private ClientService clientService;
+
+    @Mock
+    private RedirectionUriService redirectionUriService;
+
+    @Mock
+    private DeviceAuthorizationService deviceAuthorizationService;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private SessionIdService sessionIdService;
+
+    @Mock
+    private Identity identity;
+
+    @Test
+    public void isAuthnMaxAgeValid_whenMaxAgeIsZero_shouldReturnTrue() {
+        assertTrue(authorizeRestWebServiceValidator.isAuthnMaxAgeValid(0, new SessionId(), new Client()));
+    }
+
+    @Test
+    public void isAuthnMaxAgeValid_whenMaxAgeIsZeroAndDisableAuthnForMaxAgeZeroIsFalse_shouldReturnTrue() {
+        when(appConfiguration.getDisableAuthnForMaxAgeZero()).thenReturn(false);
+        assertTrue(authorizeRestWebServiceValidator.isAuthnMaxAgeValid(0, new SessionId(), new Client()));
+    }
+
+    @Test
+    public void isAuthnMaxAgeValid_whenMaxAgeIsZeroAndDisableAuthnForMaxAgeZeroIsTrue_shouldReturnFalse() {
+        when(appConfiguration.getDisableAuthnForMaxAgeZero()).thenReturn(true);
+        assertFalse(authorizeRestWebServiceValidator.isAuthnMaxAgeValid(0, new SessionId(), new Client()));
+    }
+
+    @Test
+    public void isAuthnMaxAgeValid_whenMaxAgeIsNull_shouldReturnTrue() {
+        assertTrue(authorizeRestWebServiceValidator.isAuthnMaxAgeValid(0, new SessionId(), new Client()));
+    }
+}

--- a/Server/src/test/resources/testng.xml
+++ b/Server/src/test/resources/testng.xml
@@ -10,6 +10,7 @@
         <classes>
             <class name="org.gluu.oxauth.service.ScopeServiceTest" />
             <class name="org.gluu.oxauth.model.CIBAGrantTest" />
+            <class name="org.gluu.oxauth.authorize.ws.rs.AuthorizeRestWebServiceValidatorTest" />
         </classes>
     </test>
 


### PR DESCRIPTION
Issue: https://github.com/GluuFederation/oxAuth/issues/1714

Setting max_age parameter with 0 value in a authorization request doesn't allow user to log in at all. After postlogin call user is redirected back to login page.

In addition we can introduce `disableAuthnForMaxAgeZero` with default value `false`. If `true` - authn will be disabled.

```
max_age
OPTIONAL. Maximum Authentication Age. Specifies the allowable elapsed time in seconds since the last time the End-User was actively authenticated by the OP. If the elapsed time is greater than this value, the OP MUST attempt to actively re-authenticate the End-User. (The max_age request parameter corresponds to the OpenID 2.0 PAPE [OpenID.PAPE] max_auth_age request parameter.) When max_age is used, the ID Token returned MUST include an auth_time Claim Value.
```