### PR TITLE
feat(oxauth): allow end session with expired id_token_hint (by checking signature and sid) #1721

### DIFF
--- a/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
+++ b/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
@@ -222,6 +222,8 @@ public class AppConfiguration implements Configuration {
     private Boolean useLocalCache = false;
     private Boolean fapiCompatibility = false;
     private Boolean forceIdTokenHintPrecense = false;
+    private Boolean rejectEndSessionIfIdTokenExpired = false;
+    private Boolean allowEndSessionWithUnmatchedSid = false;
     private Boolean forceOfflineAccessScopeToEnableRefreshToken = true;
     private Boolean errorReasonEnabled  = false;
     private Boolean removeRefreshTokensForClientOnLogout  = true;
@@ -491,6 +493,24 @@ public class AppConfiguration implements Configuration {
 
     public void setForceIdTokenHintPrecense(Boolean forceIdTokenHintPrecense) {
         this.forceIdTokenHintPrecense = forceIdTokenHintPrecense;
+    }
+
+    public Boolean getRejectEndSessionIfIdTokenExpired() {
+        if (rejectEndSessionIfIdTokenExpired == null) rejectEndSessionIfIdTokenExpired = false;
+        return rejectEndSessionIfIdTokenExpired;
+    }
+
+    public void setRejectEndSessionIfIdTokenExpired(Boolean rejectEndSessionIfIdTokenExpired) {
+        this.rejectEndSessionIfIdTokenExpired = rejectEndSessionIfIdTokenExpired;
+    }
+
+    public Boolean getAllowEndSessionWithUnmatchedSid() {
+        if (allowEndSessionWithUnmatchedSid == null) allowEndSessionWithUnmatchedSid = false;
+        return allowEndSessionWithUnmatchedSid;
+    }
+
+    public void setAllowEndSessionWithUnmatchedSid(Boolean allowEndSessionWithUnmatchedSid) {
+        this.allowEndSessionWithUnmatchedSid = allowEndSessionWithUnmatchedSid;
     }
 
     public Boolean getRemoveRefreshTokensForClientOnLogout() {

--- a/Server/src/main/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImpl.java
+++ b/Server/src/main/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImpl.java
@@ -8,6 +8,7 @@ package org.gluu.oxauth.session.ws.rs;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.gluu.model.security.Identity;
 import org.gluu.oxauth.audit.ApplicationAuditLogger;
@@ -20,6 +21,7 @@ import org.gluu.oxauth.model.common.SessionId;
 import org.gluu.oxauth.model.common.User;
 import org.gluu.oxauth.model.config.Constants;
 import org.gluu.oxauth.model.configuration.AppConfiguration;
+import org.gluu.oxauth.model.crypto.AbstractCryptoProvider;
 import org.gluu.oxauth.model.error.ErrorHandlingMethod;
 import org.gluu.oxauth.model.error.ErrorResponseFactory;
 import org.gluu.oxauth.model.exception.InvalidJwtException;
@@ -105,6 +107,9 @@ public class EndSessionRestWebServiceImpl implements EndSessionRestWebService {
     @Inject
     private LogoutTokenFactory logoutTokenFactory;
 
+    @Inject
+    private AbstractCryptoProvider cryptoProvider;
+
     @Override
     public Response requestEndSession(String idTokenHint, String postLogoutRedirectUri, String state, String sessionId, String sid,
                                       HttpServletRequest httpRequest, HttpServletResponse httpResponse, SecurityContext sec) {
@@ -115,8 +120,8 @@ public class EndSessionRestWebServiceImpl implements EndSessionRestWebService {
             if (StringUtils.isBlank(sid) && StringUtils.isNotBlank(sessionId))
                 sid = sessionId; // backward compatibility. WIll be removed in next major release.
 
-            Jwt idToken = validateIdTokenHint(idTokenHint, postLogoutRedirectUri);
-            validateSidRequestParameter(sid, postLogoutRedirectUri);
+            final SessionId sidSession = validateSidRequestParameter(sid, postLogoutRedirectUri);
+            Jwt idToken = validateIdTokenHint(idTokenHint, sidSession, postLogoutRedirectUri);
 
             final Pair<SessionId, AuthorizationGrant> pair = getPair(idTokenHint, sid, httpRequest);
             if (pair.getFirst() == null) {
@@ -259,7 +264,7 @@ public class EndSessionRestWebServiceImpl implements EndSessionRestWebService {
                 new URLPatternList(appConfiguration.getClientWhiteList()).isUrlListed(postLogoutRedirectUri);
     }
 
-    private void validateSidRequestParameter(String sid, String postLogoutRedirectUri) {
+    private SessionId validateSidRequestParameter(String sid, String postLogoutRedirectUri) {
         // sid is not required but if it is present then we must validate it #831
         if (StringUtils.isNotBlank(sid)) {
             SessionId sessionIdObject = sessionIdService.getSessionBySid(sid);
@@ -268,40 +273,77 @@ public class EndSessionRestWebServiceImpl implements EndSessionRestWebService {
                 log.error(reason);
                 throw new WebApplicationException(createErrorResponse(postLogoutRedirectUri, EndSessionErrorResponseType.INVALID_GRANT_AND_SESSION, reason));
             }
+            return sessionIdObject;
         }
+        return null;
     }
 
-    private Jwt validateIdTokenHint(String idTokenHint, String postLogoutRedirectUri) {
-        if (appConfiguration.getForceIdTokenHintPrecense() && StringUtils.isBlank(idTokenHint)) { // must be present for logout tests #1279
+    public Jwt validateIdTokenHint(String idTokenHint, SessionId sidSession, String postLogoutRedirectUri) {
+        final boolean isIdTokenHintRequired = BooleanUtils.isTrue(appConfiguration.getForceIdTokenHintPrecense());
+
+        if (isIdTokenHintRequired && StringUtils.isBlank(idTokenHint)) { // must be present for logout tests #1279
             final String reason = "id_token_hint is not set";
             log.trace(reason);
             throw new WebApplicationException(createErrorResponse(postLogoutRedirectUri, EndSessionErrorResponseType.INVALID_REQUEST, reason));
         }
 
-        final AuthorizationGrant tokenHintGrant = getTokenHintGrant(idTokenHint);
-        if (appConfiguration.getForceIdTokenHintPrecense() && tokenHintGrant == null) { // must be present for logout tests #1279
-            final String reason = "id_token_hint is not set";
-            log.trace(reason);
-            throw new WebApplicationException(createErrorResponse(postLogoutRedirectUri, EndSessionErrorResponseType.INVALID_REQUEST, reason));
+        if (StringUtils.isBlank(idTokenHint) && !isIdTokenHintRequired) {
+            return null;
         }
 
         // id_token_hint is not required but if it is present then we must validate it #831
-        if (StringUtils.isNotBlank(idTokenHint)) {
-            if (tokenHintGrant == null) {
+        if (StringUtils.isNotBlank(idTokenHint) || isIdTokenHintRequired) {
+            final boolean isRejectEndSessionIfIdTokenExpired = appConfiguration.getRejectEndSessionIfIdTokenExpired();
+            final AuthorizationGrant tokenHintGrant = getTokenHintGrant(idTokenHint);
+
+            if (tokenHintGrant == null && isRejectEndSessionIfIdTokenExpired) {
                 final String reason = "id_token_hint is not valid. Logout is rejected. id_token_hint can be skipped or otherwise valid value must be provided.";
                 throw new WebApplicationException(createErrorResponse(postLogoutRedirectUri, EndSessionErrorResponseType.INVALID_GRANT_AND_SESSION, reason));
             }
             try {
-                return Jwt.parse(idTokenHint);
+                final Jwt jwt = Jwt.parse(idTokenHint);
+                if (jwt == null) {
+                    log.error("Unable to parse id_token_hint as JWT: {}", idTokenHint);
+                    throw new WebApplicationException(createErrorResponse(postLogoutRedirectUri, EndSessionErrorResponseType.INVALID_GRANT_AND_SESSION, "Unable to parse id_token_hint as JWT."));
+                }
+                if (tokenHintGrant != null) { // id_token is in db
+                    return jwt;
+                }
+                if (verifyIdTokenSignature(sidSession, jwt, postLogoutRedirectUri)) {
+                    return jwt;
+                }
             } catch (InvalidJwtException e) {
                 log.error("Unable to parse id_token_hint as JWT.", e);
                 throw new WebApplicationException(createErrorResponse(postLogoutRedirectUri, EndSessionErrorResponseType.INVALID_GRANT_AND_SESSION, "Unable to parse id_token_hint as JWT."));
+            } catch (WebApplicationException e) {
+                throw e;
+            } catch (Exception e) {
+                log.error("Unable to validate id_token_hint as JWT.", e);
+                throw new WebApplicationException(createErrorResponse(postLogoutRedirectUri, EndSessionErrorResponseType.INVALID_GRANT_AND_SESSION, "Unable to validate id_token_hint as JWT."));
             }
         }
         return null;
     }
 
-    private AuthorizationGrant getTokenHintGrant(String idTokenHint) {
+    private boolean verifyIdTokenSignature(SessionId sidSession, Jwt jwt, String postLogoutRedirectUri) throws Exception {
+        // verify jwt signature if we can't find it in db
+        if (cryptoProvider.verifySignature(jwt.getSigningInput(), jwt.getEncodedSignature(), jwt.getHeader().getKeyId(),
+                    null, null, jwt.getHeader().getSignatureAlgorithm())) {
+            if (BooleanUtils.isTrue(appConfiguration.getAllowEndSessionWithUnmatchedSid())) {
+                return true;
+            }
+            final String sidClaim = jwt.getClaims().getClaimAsString("sid");
+            if (sidSession != null && StringUtils.equals(sidSession.getOutsideSid(), sidClaim)) {
+                return true;
+            }
+
+            log.error("sid claim from id_token does not match to any valid session on AS.");
+            throw new WebApplicationException(createErrorResponse(postLogoutRedirectUri, EndSessionErrorResponseType.INVALID_GRANT_AND_SESSION, "sid claim from id_token does not match to any valid session on AS."));
+        }
+        return false;
+    }
+
+    protected AuthorizationGrant getTokenHintGrant(String idTokenHint) {
         if (StringUtils.isBlank(idTokenHint)) {
             return null;
         }

--- a/Server/src/test/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImplTest.java
+++ b/Server/src/test/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImplTest.java
@@ -1,0 +1,178 @@
+package org.gluu.oxauth.session.ws.rs;
+
+import org.gluu.model.security.Identity;
+import org.gluu.oxauth.audit.ApplicationAuditLogger;
+import org.gluu.oxauth.model.common.AuthorizationGrant;
+import org.gluu.oxauth.model.common.AuthorizationGrantList;
+import org.gluu.oxauth.model.common.GrantType;
+import org.gluu.oxauth.model.common.SessionId;
+import org.gluu.oxauth.model.configuration.AppConfiguration;
+import org.gluu.oxauth.model.crypto.AbstractCryptoProvider;
+import org.gluu.oxauth.model.error.ErrorResponseFactory;
+import org.gluu.oxauth.model.jwt.Jwt;
+import org.gluu.oxauth.service.*;
+import org.gluu.oxauth.service.external.ExternalApplicationSessionService;
+import org.gluu.oxauth.service.external.ExternalEndSessionService;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.WebApplicationException;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNull;
+import static org.testng.AssertJUnit.assertNotNull;
+
+/**
+ * @author Yuriy Z
+ */
+@Listeners(MockitoTestNGListener.class)
+public class EndSessionRestWebServiceImplTest {
+
+    private static final String DUMMY_JWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2NjM2NzcxODUsImV4cCI6MTY5NTIxMzE4NSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJzaWQiOiIxMjM0IiwiUm9sZSI6IlByb2plY3QgQWRtaW5pc3RyYXRvciJ9.pmJ5kTvxyfOUGOXTzYA1DMjbF96lfCF1dVSn_70nf2Q";
+    private static final AuthorizationGrant GRANT = new AuthorizationGrant() {
+        @Override
+        public GrantType getGrantType() {
+            return GrantType.AUTHORIZATION_CODE;
+        }
+    };
+
+
+    @InjectMocks
+    private EndSessionRestWebServiceImpl endSessionRestWebService;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Mock
+    private RedirectionUriService redirectionUriService;
+
+    @Mock
+    private AuthorizationGrantList authorizationGrantList;
+
+    @Mock
+    private ExternalApplicationSessionService externalApplicationSessionService;
+
+    @Mock
+    private ExternalEndSessionService externalEndSessionService;
+
+    @Mock
+    private SessionIdService sessionIdService;
+
+    @Mock
+    private CookieService cookieService;
+
+    @Mock
+    private ClientService clientService;
+
+    @Mock
+    private GrantService grantService;
+
+    @Mock
+    private Identity identity;
+
+    @Mock
+    private ApplicationAuditLogger applicationAuditLogger;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private LogoutTokenFactory logoutTokenFactory;
+
+    @Mock
+    private AbstractCryptoProvider cryptoProvider;
+
+    @Test
+    public void validateIdTokenHint_whenIdTokenHintIsBlank_shouldGetNoError() {
+        assertNull(endSessionRestWebService.validateIdTokenHint("", null, "http://postlogout.com"));
+    }
+
+    @Test(expectedExceptions = WebApplicationException.class)
+    public void validateIdTokenHint_whenIdTokenHintIsBlankButRequired_shouldGetError() {
+        when(appConfiguration.getForceIdTokenHintPrecense()).thenReturn(true);
+
+        endSessionRestWebService.validateIdTokenHint("", null, "http://postlogout.com");
+    }
+
+    @Test(expectedExceptions = WebApplicationException.class)
+    public void validateIdTokenHint_whenIdTokenIsNotInDbAndExpiredIsNotAllowed_shouldGetError() {
+        when(appConfiguration.getRejectEndSessionIfIdTokenExpired()).thenReturn(true);
+        when(endSessionRestWebService.getTokenHintGrant("test")).thenReturn(null);
+
+        endSessionRestWebService.validateIdTokenHint("testToken", null, "http://postlogout.com");
+    }
+
+    @Test(expectedExceptions = WebApplicationException.class)
+    public void validateIdTokenHint_whenIdTokenIsNotValidJwt_shouldGetError() {
+        when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(true);
+        when(endSessionRestWebService.getTokenHintGrant("notValidJwt")).thenReturn(GRANT);
+
+        endSessionRestWebService.validateIdTokenHint("notValidJwt", null, "http://postlogout.com");
+    }
+
+    @Test
+    public void validateIdTokenHint_whenIdTokenIsValidJwt_shouldGetValidJwt() {
+        when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(true);
+        when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(GRANT);
+
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "http://postlogout.com");
+        assertNotNull(jwt);
+    }
+
+    @Test(expectedExceptions = WebApplicationException.class)
+    public void validateIdTokenHint_whenIdTokenSignatureIsBad_shouldGetError() throws Exception {
+        when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(false);
+        when(appConfiguration.getAllowEndSessionWithUnmatchedSid()).thenReturn(true);
+        when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(null);
+        when(cryptoProvider.verifySignature(anyString(), anyString(), anyString(), isNull(), isNull(), any())).thenReturn(false);
+
+        assertNull(endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "http://postlogout.com"));
+    }
+
+    @Test
+    public void validateIdTokenHint_whenIdTokenIsExpiredAndSidCheckIsNotRequired_shouldGetValidJwt() throws Exception {
+        when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(false);
+        when(appConfiguration.getAllowEndSessionWithUnmatchedSid()).thenReturn(true);
+        when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(null);
+        when(cryptoProvider.verifySignature(anyString(), anyString(), isNull(), isNull(), isNull(), any())).thenReturn(true);
+
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "http://postlogout.com");
+        assertNotNull(jwt);
+    }
+
+    @Test
+    public void validateIdTokenHint_whenIdTokenIsExpiredAndSidCheckIsRequired_shouldGetValidJwt() throws Exception {
+        when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(false);
+        when(appConfiguration.getAllowEndSessionWithUnmatchedSid()).thenReturn(false);
+        when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(null);
+        when(cryptoProvider.verifySignature(anyString(), anyString(), isNull(), isNull(), isNull(), any())).thenReturn(true);
+
+        SessionId sidSession = new SessionId();
+        sidSession.setOutsideSid("1234"); // sid encoded into DUMMY_JWT
+
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "http://postlogout.com");
+        assertNotNull(jwt);
+    }
+
+    @Test(expectedExceptions = WebApplicationException.class)
+    public void validateIdTokenHint_whenIdTokenIsExpiredAndSidCheckIsRequiredButSessionHasAnotherSid_shouldGetError() throws Exception {
+        when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(false);
+        when(appConfiguration.getAllowEndSessionWithUnmatchedSid()).thenReturn(false);
+        when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(null);
+        when(cryptoProvider.verifySignature(anyString(), anyString(), isNull(), isNull(), isNull(), any())).thenReturn(true);
+
+        SessionId sidSession = new SessionId();
+        sidSession.setOutsideSid("12345"); // sid encoded into DUMMY_JWT
+
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "http://postlogout.com");
+        assertNotNull(jwt);
+    }
+}

--- a/Server/src/test/resources/testng.xml
+++ b/Server/src/test/resources/testng.xml
@@ -11,6 +11,7 @@
             <class name="org.gluu.oxauth.service.ScopeServiceTest" />
             <class name="org.gluu.oxauth.model.CIBAGrantTest" />
             <class name="org.gluu.oxauth.authorize.ws.rs.AuthorizeRestWebServiceValidatorTest" />
+            <class name="org.gluu.oxauth.session.ws.rs.EndSessionRestWebServiceImplTest" />
         </classes>
     </test>
 


### PR DESCRIPTION
Allow end session with expired id_token_hint:

1. Verify the signature on the JWT if present, also checking that it was signed by one of oxAuth's signing keys.
2. As per the spec:
    * Use the sid claim in the it token hint to look up the session in the 0xAuth session store.
    * If a session is found, check that the aud claim in the token matches one of the client_ids belonging to the session.

If `sid` of id_token_hint does not match request will be rejected. 

New configuration properties:
- `allowEndSessionWithUnmatchedSid` with default value `false`. If `true`, `sid` check will be skipped.
- `rejectEndSessionIfIdTokenExpired` with default value `false`. If `true` and `id_token` is not found in db, request will be rejected.


https://github.com/GluuFederation/oxAuth/issues/1721