### PR TITLE
fix(oxauth): fix NPE in JwtAuthorizationRequest #1723

### DIFF
--- a/Server/src/main/java/org/gluu/oxauth/model/authorize/JwtAuthorizationRequest.java
+++ b/Server/src/main/java/org/gluu/oxauth/model/authorize/JwtAuthorizationRequest.java
@@ -463,7 +463,7 @@ public class JwtAuthorizationRequest {
     }
 
     public static JwtAuthorizationRequest createJwtRequest(String request, String requestUri, Client client, RedirectUriResponse redirectUriResponse, AbstractCryptoProvider cryptoProvider, AppConfiguration appConfiguration) {
-        validateRequestUri(requestUri, client, appConfiguration, redirectUriResponse.getState());
+        validateRequestUri(requestUri, client, appConfiguration, redirectUriResponse != null ? redirectUriResponse.getState() : null);
         final String requestFromClient = queryRequest(requestUri, redirectUriResponse, appConfiguration);
         if (StringUtils.isNotBlank(requestFromClient)) {
             request = requestFromClient;


### PR DESCRIPTION
Fix NPE

```
java.lang.NullPointerException: null
        at org.gluu.oxauth.model.authorize.JwtAuthorizationRequest.createJwtRequest(JwtAuthorizationRequest.java:466) ~[classes/:?]
        at org.gluu.oxauth.bcauthorize.ws.rs.BackchannelAuthorizeRestWebServiceImpl.requestBackchannelAuthorizationPost(BackchannelAuthorizeRestWebServiceImpl.java:167) ~[classes/:?]
        at org.gluu.oxauth.bcauthorize.ws.rs.BackchannelAuthorizeRestWebServiceImpl$Proxy$_$$_WeldClientProxy.requestBackchannelAuthorizationPost(Unknown Source) ~[classes/:?]
        at jdk.internal.reflect.GeneratedMethodAccessor660.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
```

https://github.com/GluuFederation/oxAuth/issues/1723