### PR TITLE
fix(oxauth): do not unauthenticate session on prompt=login if there was no at least 1 successful redirect to rp

### DIFF
--- a/Model/src/main/java/org/gluu/oxauth/model/util/Util.java
+++ b/Model/src/main/java/org/gluu/oxauth/model/util/Util.java
@@ -252,10 +252,14 @@ public class Util {
     }
 
     public static int parseIntSilently(String intString) {
+        return parseIntSilently(intString, -1);
+    }
+
+    public static int parseIntSilently(String intString, int defaultValue) {
         try {
             return Integer.parseInt(intString);
         } catch (Exception e) {
-            return -1;
+            return defaultValue;
         }
     }
 


### PR DESCRIPTION
fix(oxauth): do not unauthenticate session on prompt=login if there was no at least 1 successful redirect to rp

https://github.com/GluuFederation/oxAuth/issues/1712