### PR TITLE
fix(oxauth): PKCE parameters from first SSO request retains in futher calls #1733

### DIFF
--- a/Server/src/main/java/org/gluu/oxauth/service/SessionIdService.java
+++ b/Server/src/main/java/org/gluu/oxauth/service/SessionIdService.java
@@ -241,6 +241,11 @@ public class SessionIdService {
     public boolean reinitLogin(SessionId session, boolean force) {
         final Map<String, String> sessionAttributes = session.getSessionAttributes();
         final Map<String, String> currentSessionAttributes = getCurrentSessionAttributes(sessionAttributes);
+        if (log.isTraceEnabled()) {
+            log.trace("sessionAttributes: {}", sessionAttributes);
+            log.trace("currentSessionAttributes: {}", currentSessionAttributes);
+            log.trace("shouldReinitSession: {}, force: {}", shouldReinitSession(sessionAttributes, currentSessionAttributes), force);
+        }
 
         if (force || shouldReinitSession(sessionAttributes, currentSessionAttributes)) {
             sessionAttributes.putAll(currentSessionAttributes);
@@ -267,6 +272,9 @@ public class SessionIdService {
             boolean updateResult = updateSessionId(session, true, true, true);
             if (!updateResult) {
                 log.debug("Failed to update session entry: '{}'", session.getId());
+            }
+            if (log.isTraceEnabled()) {
+                log.trace("sessionAttributes after update: {}, ", session.getSessionAttributes());
             }
             return updateResult;
         }
@@ -305,13 +313,17 @@ public class SessionIdService {
         // Update from request
         final Map<String, String> currentSessionAttributes = new HashMap<>(sessionAttributes);
 
-        Map<String, String> parameterMap = externalContext.getRequestParameterMap();
-        Map<String, String> newRequestParameterMap = requestParameterService.getAllowedParameters(parameterMap);
+        Map<String, String> requestParameters = externalContext.getRequestParameterMap();
+        Map<String, String> newRequestParameterMap = requestParameterService.getAllowedParameters(requestParameters);
         for (Entry<String, String> newRequestParameterMapEntry : newRequestParameterMap.entrySet()) {
             String name = newRequestParameterMapEntry.getKey();
             if (!StringHelper.equalsIgnoreCase(name, "auth_step")) {
                 currentSessionAttributes.put(name, newRequestParameterMapEntry.getValue());
             }
+        }
+        if (!requestParameters.containsKey(AuthorizeRequestParam.CODE_CHALLENGE) || !requestParameters.containsKey(AuthorizeRequestParam.CODE_CHALLENGE_METHOD)) {
+            currentSessionAttributes.remove(AuthorizeRequestParam.CODE_CHALLENGE);
+            currentSessionAttributes.remove(AuthorizeRequestParam.CODE_CHALLENGE_METHOD);
         }
 
         return currentSessionAttributes;


### PR DESCRIPTION
PKCE parameters from first SSO request retains in futher calls #1733

https://github.com/GluuFederation/oxAuth/issues/1733