### PR TITLE
Fix: nonce validation

### DIFF
--- a/Server/src/main/java/org/gluu/oxauth/model/authorize/AuthorizeParamsValidator.java
+++ b/Server/src/main/java/org/gluu/oxauth/model/authorize/AuthorizeParamsValidator.java
@@ -35,10 +35,12 @@ public class AuthorizeParamsValidator {
             return false;
         }
 
-        if (responseTypes.contains(ResponseType.TOKEN) || responseTypes.contains(ResponseType.ID_TOKEN)) {
-            if (StringUtils.isBlank(nonce)) {
-                return false;
-            }
+        boolean existsNonce = StringUtils.isNotBlank(nonce);
+        if (!existsNonce && ((responseTypes.contains(ResponseType.CODE) && responseTypes.contains(ResponseType.ID_TOKEN))
+                || (responseTypes.contains(ResponseType.ID_TOKEN) && responseTypes.size() == 1)
+                || (responseTypes.contains(ResponseType.ID_TOKEN) && responseTypes.contains(ResponseType.TOKEN))
+                || (responseTypes.contains(ResponseType.TOKEN) && responseTypes.size() == 1))) {
+            return false;
         }
 
         boolean validParams = !responseTypes.isEmpty();


### PR DESCRIPTION
It was compared to `Janssen Project` and the method for validating the `nonce` was not the same as `oxAuth`.

This code fragment was copied into `oxAuth`.

#1795