### PR TITLE
Fix: Sector identifier is bad

### DIFF
--- a/Server/src/main/java/org/gluu/oxauth/model/registration/RegisterParamsValidator.java
+++ b/Server/src/main/java/org/gluu/oxauth/model/registration/RegisterParamsValidator.java
@@ -281,6 +281,7 @@ public class RegisterParamsValidator {
         }
 
         // Validate Sector Identifier URL
+        boolean noRedirectUriInSectorIdentifierUri = false;
         if (valid && StringUtils.isNotBlank(sectorIdentifierUrl)) {
             try {
                 URI uri = new URI(sectorIdentifierUrl);
@@ -306,12 +307,20 @@ public class RegisterParamsValidator {
             } catch (Exception e) {
                 log.debug(e.getMessage(), e);
                 valid = false;
+            } finally {
+                if (!valid) {
+                    noRedirectUriInSectorIdentifierUri = true;
+                }
             }
         }
 
         // Validate Redirect Uris checking the white list and black list
         if (valid) {
             valid = checkWhiteListRedirectUris(redirectUris) && checkBlackListRedirectUris(redirectUris);
+        }
+
+        if (noRedirectUriInSectorIdentifierUri) {
+            throw errorResponseFactory.createWebApplicationException(Response.Status.BAD_REQUEST, RegisterErrorResponseType.INVALID_CLIENT_METADATA, "Failed to validate redirect uris. No redirect_uri in sector_identifier_uri content.");
         }
 
         return valid;

--- a/Server/src/test/java/org/gluu/oxauth/model/registration/RegisterParamsValidatorTest.java
+++ b/Server/src/test/java/org/gluu/oxauth/model/registration/RegisterParamsValidatorTest.java
@@ -1,0 +1,55 @@
+package org.gluu.oxauth.model.registration;
+
+import com.beust.jcommander.internal.Lists;
+import org.gluu.oxauth.model.common.GrantType;
+import org.gluu.oxauth.model.common.ResponseType;
+import org.gluu.oxauth.model.common.SubjectType;
+import org.gluu.oxauth.model.configuration.AppConfiguration;
+import org.gluu.oxauth.model.error.ErrorResponseFactory;
+import org.gluu.oxauth.model.register.ApplicationType;
+import org.gluu.oxauth.model.register.RegisterErrorResponseType;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@Listeners(MockitoTestNGListener.class)
+public class RegisterParamsValidatorTest {
+
+    @InjectMocks
+    private RegisterParamsValidator registerParamsValidator;
+
+    @Mock
+    private Logger log;
+
+    @Mock
+    private AppConfiguration appConfiguration;
+
+    @Mock
+    private ErrorResponseFactory errorResponseFactory;
+
+    @Test
+    public void validateRedirectUris_whenSectorIdentifierDoesNotHostValidRedirectUri_shouldThrowInvalidClientMetadataError() {
+        try {
+            when(errorResponseFactory.createWebApplicationException(any(), any(), any())).thenCallRealMethod();
+            registerParamsValidator.validateRedirectUris(
+                    Lists.newArrayList(GrantType.AUTHORIZATION_CODE),
+                    Lists.newArrayList(ResponseType.CODE),
+                    ApplicationType.WEB,
+                    SubjectType.PAIRWISE,
+                    Lists.newArrayList("https://someuri.com"),
+                    "https://invaliduri.com");
+        } catch (WebApplicationException e) {
+            verify(errorResponseFactory, times(1)).createWebApplicationException(eq(Response.Status.BAD_REQUEST), eq(RegisterErrorResponseType.INVALID_CLIENT_METADATA), any());
+        }
+    }
+}


### PR DESCRIPTION
Added validation when `redirect_uri` does not exist in `sector_identifier_uri`.

#1799