### PR TITLE
chore(oxauth): jettison 1.5.2 -> 1.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<json.version>20180813</json.version>
 		<jackson.version>2.10.1</jackson.version>
 		<jackson.databind.version>2.10.1</jackson.databind.version>
-		<jettison.version>1.5.2</jettison.version>
+		<jettison.version>1.5.4</jettison.version>
 
 		<activemq.version>5.15.14</activemq.version>
 


### PR DESCRIPTION
chore(oxauth): jettison 1.5.2 -> 1.5.4