### PR TITLE
fix(oxauth): unnecessary "session not found" error messages during refresh token flow #1824

### DIFF
--- a/Server/src/main/java/org/gluu/oxauth/model/token/IdTokenFactory.java
+++ b/Server/src/main/java/org/gluu/oxauth/model/token/IdTokenFactory.java
@@ -146,7 +146,7 @@ public class IdTokenFactory {
         if (preProcessing != null) {
             preProcessing.apply(jwr);
         }
-        final SessionId session = sessionIdService.getSessionByDn(authorizationGrant.getSessionDn());
+        final SessionId session = sessionIdService.getSessionByDn(authorizationGrant.getSessionDn(), true);
         if (session != null) {
             jwr.setClaim("sid", session.getOutsideSid());
         }


### PR DESCRIPTION
fix(oxauth): unnecessary "session not found" error messages during refresh token flow #1824