### PR TITLE
fix: Illegal op_policy_uri parameter: - exclude entries with blank values from discovery response #1823

### DIFF
--- a/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
+++ b/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
@@ -268,6 +268,7 @@ public class AppConfiguration implements Configuration {
 
     private Boolean return200OnClientRegistration = true;
     private Map<String, String> dateFormatterPatterns = new HashMap<>();
+    private Boolean allowBlankValuesInDiscoveryResponse;
 
     public Boolean getSubjectIdentifierBasedOnWholeUriBackwardCompatibility() {
         return subjectIdentifierBasedOnWholeUriBackwardCompatibility;
@@ -2171,5 +2172,14 @@ public class AppConfiguration implements Configuration {
 
     public void setDateFormatterPatterns(Map<String, String> dateFormatterPatterns) {
         this.dateFormatterPatterns = dateFormatterPatterns;
+    }
+
+    public Boolean isAllowBlankValuesInDiscoveryResponse() {
+        if (allowBlankValuesInDiscoveryResponse == null) allowBlankValuesInDiscoveryResponse = false;
+        return allowBlankValuesInDiscoveryResponse;
+    }
+
+    public void setAllowBlankValuesInDiscoveryResponse(Boolean allowBlankValuesInDiscoveryResponse) {
+        this.allowBlankValuesInDiscoveryResponse = allowBlankValuesInDiscoveryResponse;
     }
 }

--- a/Server/src/main/java/org/gluu/oxauth/servlet/OpenIdConfiguration.java
+++ b/Server/src/main/java/org/gluu/oxauth/servlet/OpenIdConfiguration.java
@@ -6,6 +6,7 @@
 
 package org.gluu.oxauth.servlet;
 
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.gluu.model.GluuAttribute;
 import org.gluu.oxauth.ciba.CIBAConfigurationService;
@@ -312,6 +313,8 @@ public class OpenIdConfiguration extends HttpServlet {
 			jsonObj.put(FRONT_CHANNEL_LOGOUT_SESSION_SUPPORTED,
 					appConfiguration.getFrontChannelLogoutSessionSupported());
 
+            filterOutKeys(jsonObj, appConfiguration);
+
 			// CIBA Configuration
 			cibaConfigurationService.processConfiguration(jsonObj);
             localResponseCache.putDiscoveryResponse(jsonObj);
@@ -321,6 +324,19 @@ public class OpenIdConfiguration extends HttpServlet {
 			log.error(e.getMessage(), e);
 		}
 	}
+
+    public static void filterOutKeys(JSONObject jsonObj, AppConfiguration appConfiguration) {
+        if (BooleanUtils.isTrue(appConfiguration.isAllowBlankValuesInDiscoveryResponse())) {
+            return;
+        }
+
+        // filter out keys with blank values
+        for (String key : new HashSet<>(jsonObj.keySet())) {
+            if (jsonObj.get(key) == null || StringUtils.isBlank(jsonObj.optString(key))) {
+                jsonObj.remove(key);
+            }
+        }
+    }
 
 	private String endpointUrl(String path) {
 		return StringUtils.replace(appConfiguration.getEndSessionEndpoint(), "/end_session", path);

--- a/Server/src/test/java/org/gluu/oxauth/servlet/OpenIdConfigurationTest.java
+++ b/Server/src/test/java/org/gluu/oxauth/servlet/OpenIdConfigurationTest.java
@@ -1,0 +1,46 @@
+package org.gluu.oxauth.servlet;
+
+import org.gluu.oxauth.model.configuration.AppConfiguration;
+import org.json.JSONObject;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+
+/**
+ * @author Yuriy Z
+ */
+public class OpenIdConfigurationTest {
+
+    @Test
+    public void filterOutKeys_withBlankValues_shouldRemoveKeys() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key1", "");
+        jsonObject.put("key2", "value2");
+        jsonObject.put("key3", "  ");
+
+        OpenIdConfiguration.filterOutKeys(jsonObject, new AppConfiguration());
+
+        assertEquals("value2", jsonObject.get("key2"));
+        assertFalse(jsonObject.has("key1"));
+        assertFalse(jsonObject.has("key3"));
+    }
+
+    @Test
+    public void filterOutKeys_withBlankValuesAndAllowedBlankValuesInConfig_shouldNotRemoveKeys() {
+        final AppConfiguration appConfiguration = new AppConfiguration();
+        appConfiguration.setAllowBlankValuesInDiscoveryResponse(true);
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("key1", "");
+        jsonObject.put("key2", "value2");
+        jsonObject.put("key3", "  ");
+
+        OpenIdConfiguration.filterOutKeys(jsonObject, appConfiguration);
+
+        assertEquals("value2", jsonObject.get("key2"));
+        assertTrue(jsonObject.has("key1"));
+        assertTrue(jsonObject.has("key3"));
+    }
+}

--- a/Server/src/test/resources/testng.xml
+++ b/Server/src/test/resources/testng.xml
@@ -10,6 +10,7 @@
         <classes>
             <class name="org.gluu.oxauth.service.ScopeServiceTest" />
             <class name="org.gluu.oxauth.service.RedirectionUriServiceTest" />
+            <class name="org.gluu.oxauth.servlet.OpenIdConfigurationTest" />
             <class name="org.gluu.oxauth.model.CIBAGrantTest" />
             <class name="org.gluu.oxauth.authorize.ws.rs.AuthorizeRestWebServiceValidatorTest" />
             <class name="org.gluu.oxauth.session.ws.rs.EndSessionRestWebServiceImplTest" />


### PR DESCRIPTION
fix: Illegal op_policy_uri parameter: - exclude entries with blank values from discovery response #1823