### PR TITLE
chore(oxauth): removed oxlicense dependencies which point to old commons-httpclient lib #1836

### DIFF
--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -386,16 +386,6 @@
 			<artifactId>oxnotify-client2</artifactId>
 		</dependency>
 
-		<!-- oxLicense -->
-		<dependency>
-			<groupId>org.gluu</groupId>
-			<artifactId>oxlicense-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.gluu</groupId>
-			<artifactId>oxlicense-validator</artifactId>
-		</dependency>
-
 		<!-- Fido2 -->
 		<dependency>
 			<groupId>org.gluu</groupId>


### PR DESCRIPTION
chore(oxauth): removed oxlicense dependencies which point to old commons-httpclient lib #1836