### PR TITLE
feat(oxauth): added client_id parameter support to /end_session (4.6.0)

### DIFF
--- a/Server/src/main/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebService.java
+++ b/Server/src/main/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebService.java
@@ -33,6 +33,7 @@ public interface EndSessionRestWebService {
             @QueryParam(EndSessionRequestParam.STATE) String state,
             @QueryParam("session_id") String sessionId,
             @QueryParam("sid") String sid,
+            @QueryParam("client_id") String clientId,
             @Context HttpServletRequest httpRequest,
             @Context HttpServletResponse httpResponse,
             @Context SecurityContext securityContext);

--- a/Server/src/test/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImplTest.java
+++ b/Server/src/test/java/org/gluu/oxauth/session/ws/rs/EndSessionRestWebServiceImplTest.java
@@ -2,17 +2,16 @@ package org.gluu.oxauth.session.ws.rs;
 
 import org.gluu.model.security.Identity;
 import org.gluu.oxauth.audit.ApplicationAuditLogger;
-import org.gluu.oxauth.model.common.AuthorizationGrant;
-import org.gluu.oxauth.model.common.AuthorizationGrantList;
-import org.gluu.oxauth.model.common.GrantType;
-import org.gluu.oxauth.model.common.SessionId;
+import org.gluu.oxauth.model.common.*;
 import org.gluu.oxauth.model.configuration.AppConfiguration;
 import org.gluu.oxauth.model.crypto.AbstractCryptoProvider;
 import org.gluu.oxauth.model.error.ErrorResponseFactory;
 import org.gluu.oxauth.model.jwt.Jwt;
+import org.gluu.oxauth.model.registration.Client;
 import org.gluu.oxauth.service.*;
 import org.gluu.oxauth.service.external.ExternalApplicationSessionService;
 import org.gluu.oxauth.service.external.ExternalEndSessionService;
+import org.gluu.util.Pair;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -23,6 +22,7 @@ import org.testng.annotations.Test;
 import javax.ws.rs.WebApplicationException;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -91,15 +91,32 @@ public class EndSessionRestWebServiceImplTest {
     private AbstractCryptoProvider cryptoProvider;
 
     @Test
+    public void validatePostLogoutRedirectUri_whenValidClientIdIsPassed_shouldValidateSuccessfully() {
+        Client client = new Client();
+        client.setClientId("my_client");
+        client.setPostLogoutRedirectUris(new String[] {"http://postlogout.com"});
+
+        final SimpleAuthorizationGrant grant = mock(SimpleAuthorizationGrant.class);
+        when(grant.getClient()).thenReturn(client);
+
+        Pair<SessionId, AuthorizationGrant> pair = new Pair<>(null, grant);
+        when(appConfiguration.getAllowPostLogoutRedirectWithoutValidation()).thenReturn(false);
+
+        when(redirectionUriService.validatePostLogoutRedirectUri(anyString(), anyString())).thenReturn("http://postlogout.com");
+
+        assertNotNull(endSessionRestWebService.validatePostLogoutRedirectUri("http://postlogout.com", pair, "state", "my_client"));
+    }
+
+    @Test
     public void validateIdTokenHint_whenIdTokenHintIsBlank_shouldGetNoError() {
-        assertNull(endSessionRestWebService.validateIdTokenHint("", null, "http://postlogout.com"));
+        assertNull(endSessionRestWebService.validateIdTokenHint("", null, "http://postlogout.com", ""));
     }
 
     @Test(expectedExceptions = WebApplicationException.class)
     public void validateIdTokenHint_whenIdTokenHintIsBlankButRequired_shouldGetError() {
         when(appConfiguration.getForceIdTokenHintPrecense()).thenReturn(true);
 
-        endSessionRestWebService.validateIdTokenHint("", null, "http://postlogout.com");
+        endSessionRestWebService.validateIdTokenHint("", null, "http://postlogout.com", "");
     }
 
     @Test(expectedExceptions = WebApplicationException.class)
@@ -107,7 +124,7 @@ public class EndSessionRestWebServiceImplTest {
         when(appConfiguration.getRejectEndSessionIfIdTokenExpired()).thenReturn(true);
         when(endSessionRestWebService.getTokenHintGrant("test")).thenReturn(null);
 
-        endSessionRestWebService.validateIdTokenHint("testToken", null, "http://postlogout.com");
+        endSessionRestWebService.validateIdTokenHint("testToken", null, "http://postlogout.com", "");
     }
 
     @Test(expectedExceptions = WebApplicationException.class)
@@ -115,7 +132,7 @@ public class EndSessionRestWebServiceImplTest {
         when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(true);
         when(endSessionRestWebService.getTokenHintGrant("notValidJwt")).thenReturn(GRANT);
 
-        endSessionRestWebService.validateIdTokenHint("notValidJwt", null, "http://postlogout.com");
+        endSessionRestWebService.validateIdTokenHint("notValidJwt", null, "http://postlogout.com", "");
     }
 
     @Test
@@ -123,7 +140,7 @@ public class EndSessionRestWebServiceImplTest {
         when(appConfiguration.getEndSessionWithAccessToken()).thenReturn(true);
         when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(GRANT);
 
-        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "http://postlogout.com");
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "http://postlogout.com", "");
         assertNotNull(jwt);
     }
 
@@ -134,7 +151,7 @@ public class EndSessionRestWebServiceImplTest {
         when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(null);
         when(cryptoProvider.verifySignature(anyString(), anyString(), anyString(), isNull(), isNull(), any())).thenReturn(false);
 
-        assertNull(endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "http://postlogout.com"));
+        assertNull(endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "http://postlogout.com", ""));
     }
 
     @Test
@@ -144,7 +161,7 @@ public class EndSessionRestWebServiceImplTest {
         when(endSessionRestWebService.getTokenHintGrant(DUMMY_JWT)).thenReturn(null);
         when(cryptoProvider.verifySignature(anyString(), anyString(), isNull(), isNull(), isNull(), any())).thenReturn(true);
 
-        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "http://postlogout.com");
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, null, "http://postlogout.com", "");
         assertNotNull(jwt);
     }
 
@@ -158,7 +175,7 @@ public class EndSessionRestWebServiceImplTest {
         SessionId sidSession = new SessionId();
         sidSession.setOutsideSid("1234"); // sid encoded into DUMMY_JWT
 
-        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "http://postlogout.com");
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "http://postlogout.com", "");
         assertNotNull(jwt);
     }
 
@@ -172,7 +189,7 @@ public class EndSessionRestWebServiceImplTest {
         SessionId sidSession = new SessionId();
         sidSession.setOutsideSid("12345"); // sid encoded into DUMMY_JWT
 
-        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "http://postlogout.com");
+        final Jwt jwt = endSessionRestWebService.validateIdTokenHint(DUMMY_JWT, sidSession, "http://postlogout.com", "");
         assertNotNull(jwt);
     }
 }


### PR DESCRIPTION
feat(oxauth): added client_id parameter support to /end_session (4.6.0)

https://github.com/GluuFederation/oxAuth/issues/1853