### PR TITLE
feat(oxauth): added configuration property to AS which will allow to bypass basic client authentication restriction to query only own tokens (4.6.0)

### DIFF
--- a/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
+++ b/Model/src/main/java/org/gluu/oxauth/model/configuration/AppConfiguration.java
@@ -196,6 +196,7 @@ public class AppConfiguration implements Configuration {
 
     private Boolean introspectionAccessTokenMustHaveUmaProtectionScope = false;
     private Boolean introspectionSkipAuthorization;
+    private Boolean introspectionRestrictBasicAuthnToOwnTokens = false;
 
     private Boolean endSessionWithAccessToken;
     private String cookieDomain;
@@ -585,6 +586,15 @@ public class AppConfiguration implements Configuration {
 
     public void setIntrospectionSkipAuthorization(Boolean introspectionSkipAuthorization) {
         this.introspectionSkipAuthorization = introspectionSkipAuthorization;
+    }
+
+    public Boolean getIntrospectionRestrictBasicAuthnToOwnTokens() {
+        if (introspectionRestrictBasicAuthnToOwnTokens == null) introspectionRestrictBasicAuthnToOwnTokens = false;
+        return introspectionRestrictBasicAuthnToOwnTokens;
+    }
+
+    public void setIntrospectionRestrictBasicAuthnToOwnTokens(Boolean introspectionRestrictBasicAuthnToOwnTokens) {
+        this.introspectionRestrictBasicAuthnToOwnTokens = introspectionRestrictBasicAuthnToOwnTokens;
     }
 
     public Boolean getUmaRptAsJwt() {

--- a/Server/src/main/java/org/gluu/oxauth/introspection/ws/rs/IntrospectionWebService.java
+++ b/Server/src/main/java/org/gluu/oxauth/introspection/ws/rs/IntrospectionWebService.java
@@ -55,6 +55,8 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
+
 /**
  * @author Yuriy Zabrovarnyy
  * @version June 30, 2018
@@ -278,13 +280,13 @@ public class IntrospectionWebService {
                 String password = URLDecoder.decode(token.substring(delim + 1), Util.UTF8_STRING_ENCODING);
                 if (clientService.authenticate(clientId, password)) {
                     grant = authorizationGrantList.getAuthorizationGrantByAccessToken(accessToken);
-                    if (grant != null && !grant.getClientId().equals(clientId)) {
+                    if (isTrue(appConfiguration.getIntrospectionRestrictBasicAuthnToOwnTokens()) && grant != null && !grant.getClientId().equals(clientId)) {
                         log.trace("Failed to match grant object clientId and client id provided during authentication.");
                         return EMPTY;
                     }
                     return new Pair<>(grant, true);
                 } else {
-                    log.trace("Failed to perform basic authentication for client: " + clientId);
+                    log.trace("Failed to perform basic authentication for client: {}", clientId);
                 }
             }
         }


### PR DESCRIPTION
feat(oxauth): added configuration property to AS which will allow to bypass basic client authentication restriction to query only own tokens (4.6.0)

https://github.com/GluuFederation/oxAuth/issues/1865