### PR TITLE
feat(oxauth): uppercased typ=JWT #1903

### DIFF
--- a/Model/src/main/java/org/gluu/oxauth/model/jwt/JwtType.java
+++ b/Model/src/main/java/org/gluu/oxauth/model/jwt/JwtType.java
@@ -12,7 +12,13 @@ package org.gluu.oxauth.model.jwt;
  */
 public enum JwtType {
 
-    JWT;
+    JWT("JWT");
+
+    private final String paramName;
+
+    JwtType(String paramName) {
+        this.paramName = paramName;
+    }
 
     /**
      * Returns the corresponding {@link JwtType} for a parameter.
@@ -29,5 +35,14 @@ public enum JwtType {
             }
         }
         return null;
+    }
+
+    public String getParamName() {
+        return paramName;
+    }
+
+    @Override
+    public String toString() {
+        return paramName;
     }
 }

--- a/Model/src/test/java/org/gluu/oxauth/model/jwt/JwtTypeTest.java
+++ b/Model/src/test/java/org/gluu/oxauth/model/jwt/JwtTypeTest.java
@@ -1,0 +1,16 @@
+package org.gluu.oxauth.model.jwt;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author Yuriy Z
+ */
+public class JwtTypeTest {
+
+    @Test
+    public void jwtTypeHeader_mustBeUppercased() {
+        assertEquals(JwtType.JWT.toString(), "JWT");
+    }
+}


### PR DESCRIPTION
feat(oxauth): uppercased typ=JWT #1903

Closes #1903

```
If present, it is RECOMMENDED that
   its value be "JWT" to indicate that this object is a JWT.  While
   media type names are not case sensitive, it is RECOMMENDED that "JWT"
   always be spelled using uppercase characters for compatibility with
   legacy implementations.  Use of this Header Parameter is OPTIONAL.
```