### PR TITLE
Removed  whitespace from login.xhtml login button value attribute and empty login.login property from oxauth.properties.

### DIFF
--- a/Server/src/main/resources/oxauth.properties
+++ b/Server/src/main/resources/oxauth.properties
@@ -24,7 +24,7 @@ login.failedToDeny=Failed to deny authorization.
 login.userAlreadyAuthenticated=User is already authenticated. Re-send authorization request (must be handled by RP).
 login.youDontHavePermission=You don't have permissions.
 login.forgotYourPassword = Forgot your password?
-login.login
+
 fido2.touch.verification.usedevice=Use Touch ID on your Apple device to sign in to your Gluu account.
 fido2.touch.verification.insertkey = Place your finger on the Touch ID.
 fido2.touch.verification.useit=Click <b>Ok</b> to enable the Touch ID.

--- a/Server/src/main/webapp/login.xhtml
+++ b/Server/src/main/webapp/login.xhtml
@@ -66,7 +66,7 @@
 							<div class="col-sm-offset-2 offset-md-2 col-sm-8 col-md-8">
 								<h:commandButton id="loginButton"
 									style="background-color: #00BE79; color:white;"
-									styleClass="btn col-sm-12" value="    #{msgs['login.login']}"
+									styleClass="btn col-sm-12" value="#{msgs['login.login']}"
 									onclick="checkRemembeMe()" iconAwesome="fa-sign-in"
 									action="#{authenticator.authenticate}" />
 							</div>


### PR DESCRIPTION
The "Login" text was not visible in the login button of the login form.
This fixes it.